### PR TITLE
Remove unnessary install Yarn command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ steps:
   with:
     node-version: '10.x'
     registry-url: <registry url>
-- run: npm install -g yarn
 - run: yarn install
 - run: yarn publish
   env:


### PR DESCRIPTION
According to the [docs](https://help.github.com/en/articles/software-in-virtual-environments-for-github-actions), Yarn is installed by default.