### PR TITLE
Update README to include yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@
   <a href="https://github.com/actions/setup-node"><img alt="GitHub Actions status" src="https://github.com/actions/setup-node/workflows/Main%20workflow/badge.svg"></a>
 </p>
 
-This action sets by node environment for use in actions by:
+This action sets up a node environment for use in actions, including npm and yarn.  It:
 
-- optionally downloading and caching a version of node - npm by version spec and add to PATH
-- registering problem matchers for error output 
+- sets up the specified version of node (downloading it if it's not already available)
+- adds node, npm and yarn to the PATH
+- registers problem matchers for error output 
 
 # Usage
 


### PR DESCRIPTION
A user indicated that it was not clear that the `setup-node` action took care of yarn, and tried using an incompatible third-party action.  Better specify that yarn is included above the fold.