### PR TITLE
Get correct url for arm dist

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -25,7 +25,7 @@ const os = __importStar(require("os"));
 const path = __importStar(require("path"));
 const semver = __importStar(require("semver"));
 let osPlat = os.platform();
-let osArch = os.arch();
+let osArch = translateArchToDistUrl(os.arch());
 if (!tempDirectory) {
     let baseLocation;
     if (process.platform === 'win32') {
@@ -90,13 +90,13 @@ function queryLatestMatch(versionSpec) {
         let dataFileName;
         switch (osPlat) {
             case 'linux':
-                dataFileName = 'linux-' + osArch;
+                dataFileName = `linux-${osArch}`;
                 break;
             case 'darwin':
-                dataFileName = 'osx-' + osArch + '-tar';
+                dataFileName = `osx-${osArch}-tar`;
                 break;
             case 'win32':
-                dataFileName = 'win-' + osArch + '-exe';
+                dataFileName = `win-${osArch}-exe`;
                 break;
             default:
                 throw new Error(`Unexpected OS '${osPlat}'`);
@@ -149,10 +149,10 @@ function acquireNode(version) {
         //
         version = semver.clean(version) || '';
         let fileName = osPlat == 'win32'
-            ? 'node-v' + version + '-win-' + os.arch()
-            : 'node-v' + version + '-' + osPlat + '-' + os.arch();
-        let urlFileName = osPlat == 'win32' ? fileName + '.7z' : fileName + '.tar.gz';
-        let downloadUrl = 'https://nodejs.org/dist/v' + version + '/' + urlFileName;
+            ? `node-v${version}-win-${osArch}`
+            : `node-v${version}-${osPlat}-${osArch}`;
+        let urlFileName = osPlat == 'win32' ? `${fileName}.7z` : `${fileName}.tar.gz`;
+        let downloadUrl = `https://nodejs.org/dist/v${version}/${urlFileName}`;
         let downloadPath;
         try {
             downloadPath = yield tc.downloadTool(downloadUrl);
@@ -202,8 +202,8 @@ function acquireNodeFromFallbackLocation(version) {
         let exeUrl;
         let libUrl;
         try {
-            exeUrl = `https://nodejs.org/dist/v${version}/win-${os.arch()}/node.exe`;
-            libUrl = `https://nodejs.org/dist/v${version}/win-${os.arch()}/node.lib`;
+            exeUrl = `https://nodejs.org/dist/v${version}/win-${osArch}/node.exe`;
+            libUrl = `https://nodejs.org/dist/v${version}/win-${osArch}/node.lib`;
             const exePath = yield tc.downloadTool(exeUrl);
             yield io.cp(exePath, path.join(tempDir, 'node.exe'));
             const libPath = yield tc.downloadTool(libUrl);
@@ -224,4 +224,14 @@ function acquireNodeFromFallbackLocation(version) {
         }
         return yield tc.cacheDir(tempDir, 'node', version);
     });
+}
+// os.arch does not always match the relative download url, e.g.
+// os.arch == 'arm' != node-v12.13.1-linux-armv7l.tar.gz
+function translateArchToDistUrl(arch) {
+    switch (arch) {
+        case 'arm':
+            return 'armv7l';
+        default:
+            return arch;
+    }
 }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -234,6 +234,9 @@ async function acquireNodeFromFallbackLocation(
 
 // os.arch does not always match the relative download url, e.g.
 // os.arch == 'arm' != node-v12.13.1-linux-armv7l.tar.gz
+// All other currently supported architectures match, e.g.:
+//   os.arch = arm64 => https://nodejs.org/dist/v{VERSION}/node-v{VERSION}-{OS}-arm64.tar.gz
+//   os.arch = x64 => https://nodejs.org/dist/v{VERSION}/node-v{VERSION}-{OS}-x64.tar.gz
 function translateArchToDistUrl(arch: string): string {
   switch (arch) {
     case 'arm':


### PR DESCRIPTION
`setup-node` doesnt work on arm / arm32 / armv7l because in node `os.arch()` returns `arm` but their download urls use `armv7l` 

cc @hross 

Also cleaned up some strings for consistency while I was there

Sample workflow:
```yaml
on:
  push:
    paths:
    - .github/workflows/setup-multiarch.yaml

jobs:
  x86_64:
    runs-on: ubuntu-latest
    steps:
    - uses: actions/setup-node@arm-installer
    - run: uname -a && echo $PATH && file $(which node) && node --version
  arm:
    runs-on: [ self-hosted, arm ]
    steps:
    - uses: actions/setup-node@arm-installer
      with:
        node-version: '10.x'
    - run: uname -a && echo $PATH && file $(which node) && node --version
  arm64:
    runs-on: [ self-hosted, arm64 ]
    steps:
    - uses: actions/setup-node@arm-installer
      with:
        node-version: '10.x'
    - run: uname -a && echo $PATH && file $(which node) && node --version
```

```
#  Run uname -a && echo $PATH && file $(which node) && node --version 0s
v10.17.0
Run uname -a && echo $PATH && file $(which node) && node --version
Linux fv-az19 5.0.0-1025-azure #27~18.04.1-Ubuntu SMP Mon Nov 11 15:19:19 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
/opt/hostedtoolcache/node/10.17.0/x64/bin:/usr/share/rust/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
/opt/hostedtoolcache/node/10.17.0/x64/bin/node: ELF 64-bit LSB executable, x86-64, version 1 (GNU/Linux), dynamically linked, interpreter /lib64/l, for GNU/Linux 2.6.18, BuildID[sha1]=de7e5987e03fe3b2cfb5d586c853465bb4caf4e2, with debug_info, not stripped
v10.17.0
```

```
# Run uname -a && echo $PATH && file $(which node) && node --version
Linux raspberrypi 4.19.83-v8+ #1277 SMP PREEMPT Mon Nov 11 16:53:30 GMT 2019 aarch64 GNU/Linux
/home/pi/runners/actions-runner-linux-arm-2.161.0/_work/_tool/node/10.17.0/arm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/games:/usr/games
/home/pi/runners/actions-runner-linux-arm-2.161.0/_work/_tool/node/10.17.0/arm/bin/node: ELF 32-bit LSB executable, ARM, EABI5 version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 3.16.42, with debug_info, not stripped
v10.17.0
```

```
# Run uname -a && echo $PATH && file $(which node) && node --version
Linux raspberrypi 4.19.83-v8+ #1277 SMP PREEMPT Mon Nov 11 16:53:30 GMT 2019 aarch64 GNU/Linux
/home/pi/runners/actions-runner-linux-arm64-2.161.0/_work/_tool/node/10.17.0/arm64/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/games:/usr/games
/home/pi/runners/actions-runner-linux-arm64-2.161.0/_work/_tool/node/10.17.0/arm64/bin/node: ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, BuildID[sha1]=42d484b0e94174ea9a29809588be17d0ea7b17de, with debug_info, not stripped
v10.17.0
```