### PR TITLE
Tslint prose matcher

### DIFF
--- a/.github/tslint-prose.json
+++ b/.github/tslint-prose.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "tslint-prose",
+      "pattern": [
+        {
+          "regexp": "^(WARNING|ERROR):\\s\\\/home\\\/runner\\\/work\\\/[^\\\/]+\\\/[^\\\/]+\\\/(\\S+):(\\d+):(\\d+)\\s-\\s(.+)$",
+          "severity": 1,
+          "file": 2,
+          "line": 3,
+          "column": 4,
+          "message": 5
+        }
+      ]
+    }
+  ]
+}

--- a/lib/setup-node.js
+++ b/lib/setup-node.js
@@ -44,6 +44,7 @@ function run() {
             console.log(`##[add-matcher]${path.join(matchersPath, 'tsc.json')}`);
             console.log(`##[add-matcher]${path.join(matchersPath, 'eslint-stylish.json')}`);
             console.log(`##[add-matcher]${path.join(matchersPath, 'eslint-compact.json')}`);
+            console.log(`##[add-matcher]${path.join(matchersPath, 'tslint-prose.json')}`);
         }
         catch (error) {
             core.setFailed(error.message);

--- a/src/setup-node.ts
+++ b/src/setup-node.ts
@@ -33,6 +33,9 @@ async function run() {
     console.log(
       `##[add-matcher]${path.join(matchersPath, 'eslint-compact.json')}`
     );
+    console.log(
+      `##[add-matcher]${path.join(matchersPath, 'tslint-prose.json')}`
+    );
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
This PR aims to add support for the default tslint formatter: `prose`.

As tslint uses absolute paths, we need to filter part of the path.

It currently assumes the following path:
`/home/runner/work/<repo name>/<repo name>/<path in repo>`

Can anyone confirm that the path will always follow the format above?