### PR TITLE
Prettier 2.0.4

### DIFF
--- a/__tests__/authutil.test.ts
+++ b/__tests__/authutil.test.ts
@@ -10,11 +10,7 @@ describe('installer tests', () => {
     const tempDir = path.join(
       __dirname,
       'runner',
-      path.join(
-        Math.random()
-          .toString(36)
-          .substring(7)
-      ),
+      path.join(Math.random().toString(36).substring(7)),
       'temp'
     );
     await io.rmRF(tempDir);

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -13,21 +13,13 @@ describe('installer tests', () => {
     toolDir = path.join(
       __dirname,
       'runner',
-      path.join(
-        Math.random()
-          .toString(36)
-          .substring(7)
-      ),
+      path.join(Math.random().toString(36).substring(7)),
       'tools'
     );
     const tempDir = path.join(
       __dirname,
       'runner',
-      path.join(
-        Math.random()
-          .toString(36)
-          .substring(7)
-      ),
+      path.join(Math.random().toString(36).substring(7)),
       'temp'
     );
     await io.rmRF(toolDir);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4197,9 +4197,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.4.tgz",
+      "integrity": "sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@zeit/ncc": "^0.21.0",
     "jest": "^24.8.0",
     "jest-circus": "^24.7.1",
-    "prettier": "^1.17.1",
+    "prettier": "2.0.4",
     "ts-jest": "^24.0.2",
     "typescript": "^3.5.1"
   }


### PR DESCRIPTION
This upgrades us to the latest version of [Prettier](https://prettier.io/). See [the blog post introducing version 2.0](https://prettier.io/blog/2020/03/21/2.0.0.html).

I also switched to pinning an exact version of Prettier, [as suggested in the install docs](https://prettier.io/docs/en/install.html).