### PR TITLE
Run test job on windows-latest

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,7 +28,10 @@ jobs:
         run: __tests__/verify-no-unstaged-changes.sh
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, windows-latest]
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v2
       - name: Clear tool cache

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,7 +28,10 @@ jobs:
         run: __tests__/verify-no-unstaged-changes.sh
 
   test:
-    runs-on: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest, windows-latest]
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
This adds running `windows-latest` to the set of OS's that we run E2E tests on. This ensures we have coverage for non-nix based operating systems.