### PR TITLE
Clarifications to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ steps:
     node-version: '12'
 ```
 
-It will first check the local cache for a semver match.  The hosted images have been updated with the latest of each LTS from v8, v10, v12, and v14. `self-hosted` machines will benefit from the cache as well only downloading once.  It will pull LTS versions from [node-versions releases](https://github.com/actions/node-versions/releases) and on miss or failure, it will fall back to the previous behavior of download directly from [node dist](https://nodejs.org/dist/).
+The action will first check the local cache for a semver match. The hosted images have been updated with the latest of each LTS from v8, v10, v12, and v14. `self-hosted` machines will benefit from the cache as well only downloading once. The action will pull LTS versions from [node-versions releases](https://github.com/actions/node-versions/releases) and on miss or failure will fall back to the previous behavior of downloading directly from [node dist](https://nodejs.org/dist/).
 
-The `node-version` input is optional.  If not supplied, node which is in your PATH will be used.  However, this action will still register problem matchers and support auth features.  So setting up the node environment is still a valid scenario without downloading and caching versions.
+The `node-version` input is optional. If not supplied, the node version that is PATH will be used. However, this action will still register problem matchers and support auth features. So setting up the node environment is still a valid scenario without downloading and caching versions.
 
 # Usage
 
@@ -41,9 +41,12 @@ steps:
 - run: npm test
 ```
 
-Check latest version:  
-> In basic example, without `check-latest` flag, the action tries to resolve version from local cache firstly and download only if it is not found. Local cache on image is updated with a couple of weeks latency.  
-`check-latest` flag forces the action to check if the cached version is the latest one. It reduces latency significantly but it is much more likely to incur version downloading.
+Check latest version:
+
+In the basic example above, the `check-latest` flag defaults to `false`. When set to `false`, the action tries to first resolve a version of node from the local cache. For information regarding locally cached versions of Node on GitHub hosted runners, check out [GitHub Actions Virtual Environments](https://github.com/actions/virtual-environments). The local version of Node in cache gets updated every couple of weeks. If unable to find a specific version in the cache, the action will then attempt to download a version of Node. Use the default or set `check-latest` to `false` if you prefer stability and if you want to ensure a specific version of Node is always used.
+
+If `check-latest` is set to `true`, the action first checks if the cached version is the latest one. If the locally cached version is not the most up-to-date, a version of Node will then be downloaded. Set `check-latest` to `true` it you want the most up-to-date version of Node to always be used.
+
 ```yaml
 steps:
 - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ In the basic example above, the `check-latest` flag defaults to `false`. When se
 
 If `check-latest` is set to `true`, the action first checks if the cached version is the latest one. If the locally cached version is not the most up-to-date, a version of Node will then be downloaded. Set `check-latest` to `true` it you want the most up-to-date version of Node to always be used.
 
+> Setting `check-latest` to `true` has performance implications as downloading versions of Node is slower than using cached versions
+
 ```yaml
 steps:
 - uses: actions/checkout@v2


### PR DESCRIPTION
Small clarifications and grammatical fixes to the `README`.

🎨 [Rendered](https://github.com/actions/setup-node/blob/f7f202971f26dc6c0fcfadbeba59d1af24aa242f/README.md) 🖌