### PR TITLE
refactor: use core.info instead of console.log

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4656,9 +4656,9 @@ function run() {
                 auth.configAuthentication(registryUrl, alwaysAuth);
             }
             const matchersPath = path.join(__dirname, '..', '.github');
-            console.log(`##[add-matcher]${path.join(matchersPath, 'tsc.json')}`);
-            console.log(`##[add-matcher]${path.join(matchersPath, 'eslint-stylish.json')}`);
-            console.log(`##[add-matcher]${path.join(matchersPath, 'eslint-compact.json')}`);
+            core.info(`##[add-matcher]${path.join(matchersPath, 'tsc.json')}`);
+            core.info(`##[add-matcher]${path.join(matchersPath, 'eslint-stylish.json')}`);
+            core.info(`##[add-matcher]${path.join(matchersPath, 'eslint-compact.json')}`);
         }
         catch (error) {
             core.setFailed(error.message);

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,11 +31,11 @@ export async function run() {
     }
 
     const matchersPath = path.join(__dirname, '..', '.github');
-    console.log(`##[add-matcher]${path.join(matchersPath, 'tsc.json')}`);
-    console.log(
+    core.info(`##[add-matcher]${path.join(matchersPath, 'tsc.json')}`);
+    core.info(
       `##[add-matcher]${path.join(matchersPath, 'eslint-stylish.json')}`
     );
-    console.log(
+    core.info(
       `##[add-matcher]${path.join(matchersPath, 'eslint-compact.json')}`
     );
   } catch (error) {


### PR DESCRIPTION
Use `core.info` instead of `console.log` for keeping it consistent with other files.