### PR TITLE
Node version file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ steps:
 - run: npm test
 ```
 
+Node version file:
+
+The `node-version-file` input allows you to use a file within your repository which contains the version of node your project uses for example `.nvmrc`. If both the `node-version` and the `node-version-file` inputs are provided the `node-version` input is used.
+> The node version file is read from the project root
+
+```yaml
+steps:
+- uses: actions/checkout@v2
+- uses: actions/setup-node@v2
+  with:
+    node-version-file: '.nvmrc'
+- run: npm install
+- run: npm test
+```
+
 Matrix Testing:
 ```yaml
 jobs:

--- a/__tests__/node-version-file.test.ts
+++ b/__tests__/node-version-file.test.ts
@@ -1,0 +1,88 @@
+import * as nv from '../src/node-version';
+import * as nvf from '../src/node-version-file';
+
+let nodeTestDist = require('./data/node-dist-index.json');
+
+describe('node-version-file', () => {
+  let getVersionsFromDist: jest.SpyInstance;
+
+  beforeEach(() => {
+    // @actions/core
+    console.log('::stop-commands::stoptoken'); // Disable executing of runner commands when running tests in actions
+
+    getVersionsFromDist = jest.spyOn(nv, 'getVersionsFromDist');
+
+    // gets
+    getVersionsFromDist.mockImplementation(() => <nv.INodeVersion>nodeTestDist);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.clearAllMocks();
+    //jest.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    console.log('::stoptoken::'); // Re-enable executing of runner commands when running tests in actions
+  }, 100000);
+
+  //--------------------------------------------------
+  // Manifest find tests
+  //--------------------------------------------------
+  describe('parseNodeVersionFile', () => {
+    it('without `v` prefix', async () => {
+      // Arrange
+      const versionSpec = '12';
+
+      // Act
+      const result = await nvf.parseNodeVersionFile(versionSpec);
+
+      // Assert
+      expect(result).toBe(versionSpec);
+    });
+
+    it('lts/*', async () => {
+      // Arrange
+      const versionSpec = 'lts/*';
+
+      // Act
+      const result = await nvf.parseNodeVersionFile(versionSpec);
+
+      // Assert
+      expect(result).toMatch(/^\d+\.\d+\.\d+$/);
+    });
+
+    it('lts/erbium', async () => {
+      // Arrange
+      const versionSpec = 'lts/*';
+
+      // Act
+      const result = await nvf.parseNodeVersionFile(versionSpec);
+
+      // Assert
+      expect(result).toMatch(/\d\.\d\.\d/);
+    });
+
+    it('partial syntax like 12', async () => {
+      // Arrange
+      const versionSpec = '12';
+
+      // Act
+      const result = await nvf.parseNodeVersionFile(versionSpec);
+
+      // Assert
+      expect(result).toBe(versionSpec);
+    });
+
+    it('partial syntax like 12.16', async () => {
+      // Arrange
+      const versionSpec = '12.16';
+
+      // Act
+      const result = await nvf.parseNodeVersionFile(versionSpec);
+
+      // Assert
+      expect(result).toBe(versionSpec);
+    });
+  });
+});

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,8 @@ inputs:
     default: 'false'
   node-version:
     description: 'Version Spec of the version to use.  Examples: 12.x, 10.15.1, >=10.15.0'
+  node-version-file:
+    description: 'File containing the version Spec of the version to use.  Examples: .nvmrc'
   check-latest:
     description: 'Set this option if you want the action to check for the latest available version that satisfies the version spec'
     default: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -4692,6 +4692,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
 const installer = __importStar(__webpack_require__(749));
 const auth = __importStar(__webpack_require__(202));
+const fs = __webpack_require__(747);
 const path = __importStar(__webpack_require__(622));
 const url_1 = __webpack_require__(835);
 function run() {
@@ -4704,6 +4705,14 @@ function run() {
             let version = core.getInput('node-version');
             if (!version) {
                 version = core.getInput('version');
+            }
+            if (!version) {
+                const versionFile = core.getInput('node-version-file');
+                if (!!versionFile) {
+                    const versionFilePath = path.join(__dirname, '..', versionFile);
+                    version = fs.readFileSync(versionFilePath, 'utf8');
+                    core.info(`Resolved ${versionFile} as ${version}`);
+                }
             }
             if (version) {
                 let token = core.getInput('token');

--- a/dist/index.js
+++ b/dist/index.js
@@ -3030,6 +3030,82 @@ module.exports = windowsRelease;
 
 /***/ }),
 
+/***/ 74:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const semvar = __importStar(__webpack_require__(280));
+const node_version_1 = __webpack_require__(708);
+function parseNodeVersionFile(contents) {
+    return __awaiter(this, void 0, void 0, function* () {
+        contents = contents.trim();
+        if (/^v\d/.test(contents)) {
+            contents = contents.substring(1);
+        }
+        const nodeVersions = yield node_version_1.getVersionsFromDist();
+        let nodeVersion;
+        if (contents.startsWith('lts/')) {
+            nodeVersion = findLatestLts(nodeVersions, contents).version;
+        }
+        else if (semvar.valid(contents) || isPartialMatch(contents)) {
+            nodeVersion = contents;
+        }
+        else {
+            throw new Error(`Couldn't resolve node version: '${contents}'`);
+        }
+        return stripVPrefix(nodeVersion);
+    });
+}
+exports.parseNodeVersionFile = parseNodeVersionFile;
+function findLatestLts(nodeVersions, codename) {
+    let nodeVersion;
+    if (codename === 'lts/*') {
+        nodeVersion = nodeVersions.reduce((latest, nodeVersion) => {
+            if (!nodeVersion.lts) {
+                return latest;
+            }
+            return semvar.gt(nodeVersion.version, latest.version)
+                ? nodeVersion
+                : latest;
+        });
+    }
+    else {
+        codename = codename.replace('lts/', '').toLowerCase();
+        nodeVersion = nodeVersions.find(nodeVersion => `${nodeVersion.lts}`.toLowerCase() === codename);
+    }
+    if (!nodeVersion) {
+        throw new Error(`Couldn't find matching release for codename: '${codename}'`);
+    }
+    return nodeVersion;
+}
+function isPartialMatch(version) {
+    return /^\d+(\.\d+(\.\d+)?)?$/.test(version);
+}
+function stripVPrefix(version) {
+    return /^v\d/.test(version) ? version.substring(1) : version;
+}
+//# sourceMappingURL=node-version-file.js.map
+
+/***/ }),
+
 /***/ 82:
 /***/ (function(__unusedmodule, exports) {
 
@@ -4695,6 +4771,7 @@ const auth = __importStar(__webpack_require__(202));
 const fs = __webpack_require__(747);
 const path = __importStar(__webpack_require__(622));
 const url_1 = __webpack_require__(835);
+const node_version_file_1 = __webpack_require__(74);
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -4710,7 +4787,7 @@ function run() {
                 const versionFile = core.getInput('node-version-file');
                 if (!!versionFile) {
                     const versionFilePath = path.join(__dirname, '..', versionFile);
-                    version = fs.readFileSync(versionFilePath, 'utf8');
+                    version = yield node_version_file_1.parseNodeVersionFile(fs.readFileSync(versionFilePath, 'utf8'));
                     core.info(`Resolved ${versionFile} as ${version}`);
                 }
             }
@@ -12969,6 +13046,45 @@ module.exports = {"activity":{"checkStarringRepo":{"method":"GET","params":{"own
 
 /***/ }),
 
+/***/ 708:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const hc = __importStar(__webpack_require__(539));
+function getVersionsFromDist() {
+    return __awaiter(this, void 0, void 0, function* () {
+        let dataUrl = 'https://nodejs.org/dist/index.json';
+        let httpClient = new hc.HttpClient('setup-node', [], {
+            allowRetries: true,
+            maxRetries: 3
+        });
+        let response = yield httpClient.getJson(dataUrl);
+        return response.result || [];
+    });
+}
+exports.getVersionsFromDist = getVersionsFromDist;
+//# sourceMappingURL=node-version.js.map
+
+/***/ }),
+
 /***/ 722:
 /***/ (function(module) {
 
@@ -13072,7 +13188,7 @@ module.exports = require("fs");
 /***/ }),
 
 /***/ 749:
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
@@ -13096,12 +13212,12 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const os = __webpack_require__(87);
 const assert = __importStar(__webpack_require__(357));
 const core = __importStar(__webpack_require__(470));
-const hc = __importStar(__webpack_require__(539));
 const io = __importStar(__webpack_require__(1));
 const tc = __importStar(__webpack_require__(533));
 const path = __importStar(__webpack_require__(622));
 const semver = __importStar(__webpack_require__(280));
 const fs = __webpack_require__(747);
+const node_version_1 = __webpack_require__(708);
 function getNode(versionSpec, stable, checkLatest, auth) {
     return __awaiter(this, void 0, void 0, function* () {
         let osPlat = os.platform();
@@ -13312,7 +13428,7 @@ function queryDistForMatch(versionSpec) {
                 throw new Error(`Unexpected OS '${osPlat}'`);
         }
         let versions = [];
-        let nodeVersions = yield module.exports.getVersionsFromDist();
+        let nodeVersions = yield node_version_1.getVersionsFromDist();
         nodeVersions.forEach((nodeVersion) => {
             // ensure this version supports your os and platform
             if (nodeVersion.files.indexOf(dataFileName) >= 0) {
@@ -13324,18 +13440,6 @@ function queryDistForMatch(versionSpec) {
         return version;
     });
 }
-function getVersionsFromDist() {
-    return __awaiter(this, void 0, void 0, function* () {
-        let dataUrl = 'https://nodejs.org/dist/index.json';
-        let httpClient = new hc.HttpClient('setup-node', [], {
-            allowRetries: true,
-            maxRetries: 3
-        });
-        let response = yield httpClient.getJson(dataUrl);
-        return response.result || [];
-    });
-}
-exports.getVersionsFromDist = getVersionsFromDist;
 // For non LTS versions of Node, the files we need (for Windows) are sometimes located
 // in a different folder than they normally are for other versions.
 // Normally the format is similar to: https://nodejs.org/dist/v5.10.1/node-v5.10.1-win-x64.7z

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,21 +1,12 @@
 import os = require('os');
 import * as assert from 'assert';
 import * as core from '@actions/core';
-import * as hc from '@actions/http-client';
 import * as io from '@actions/io';
 import * as tc from '@actions/tool-cache';
 import * as path from 'path';
 import * as semver from 'semver';
 import fs = require('fs');
-
-//
-// Node versions interface
-// see https://nodejs.org/dist/index.json
-//
-export interface INodeVersion {
-  version: string;
-  files: string[];
-}
+import {INodeVersion, getVersionsFromDist} from './node-version';
 
 interface INodeVersionInfo {
   downloadUrl: string;
@@ -274,7 +265,7 @@ async function queryDistForMatch(versionSpec: string): Promise<string> {
   }
 
   let versions: string[] = [];
-  let nodeVersions = await module.exports.getVersionsFromDist();
+  let nodeVersions = await getVersionsFromDist();
 
   nodeVersions.forEach((nodeVersion: INodeVersion) => {
     // ensure this version supports your os and platform
@@ -286,16 +277,6 @@ async function queryDistForMatch(versionSpec: string): Promise<string> {
   // get the latest version that matches the version spec
   let version: string = evaluateVersions(versions, versionSpec);
   return version;
-}
-
-export async function getVersionsFromDist(): Promise<INodeVersion[]> {
-  let dataUrl = 'https://nodejs.org/dist/index.json';
-  let httpClient = new hc.HttpClient('setup-node', [], {
-    allowRetries: true,
-    maxRetries: 3
-  });
-  let response = await httpClient.getJson<INodeVersion[]>(dataUrl);
-  return response.result || [];
 }
 
 // For non LTS versions of Node, the files we need (for Windows) are sometimes located

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import * as auth from './authutil';
 import fs = require('fs');
 import * as path from 'path';
 import {URL} from 'url';
+import {parseNodeVersionFile} from './node-version-file';
 
 export async function run() {
   try {
@@ -21,7 +22,9 @@ export async function run() {
 
       if (!!versionFile) {
         const versionFilePath = path.join(__dirname, '..', versionFile);
-        version = fs.readFileSync(versionFilePath, 'utf8');
+        version = await parseNodeVersionFile(
+          fs.readFileSync(versionFilePath, 'utf8')
+        );
         core.info(`Resolved ${versionFile} as ${version}`);
       }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import * as core from '@actions/core';
 import * as installer from './installer';
 import * as auth from './authutil';
+import fs = require('fs');
 import * as path from 'path';
 import {URL} from 'url';
 
@@ -13,6 +14,16 @@ export async function run() {
     let version = core.getInput('node-version');
     if (!version) {
       version = core.getInput('version');
+    }
+
+    if (!version) {
+      const versionFile = core.getInput('node-version-file');
+
+      if (!!versionFile) {
+        const versionFilePath = path.join(__dirname, '..', versionFile);
+        version = fs.readFileSync(versionFilePath, 'utf8');
+        core.info(`Resolved ${versionFile} as ${version}`);
+      }
     }
 
     if (version) {

--- a/src/node-version-file.ts
+++ b/src/node-version-file.ts
@@ -1,0 +1,65 @@
+import * as semvar from 'semver';
+import {INodeVersion, getVersionsFromDist} from './node-version';
+
+export async function parseNodeVersionFile(contents: string): Promise<string> {
+  contents = contents.trim();
+
+  if (/^v\d/.test(contents)) {
+    contents = contents.substring(1);
+  }
+
+  const nodeVersions = await getVersionsFromDist();
+
+  let nodeVersion: string;
+
+  if (contents.startsWith('lts/')) {
+    nodeVersion = findLatestLts(nodeVersions, contents).version;
+  } else if (semvar.valid(contents) || isPartialMatch(contents)) {
+    nodeVersion = contents;
+  } else {
+    throw new Error(`Couldn't resolve node version: '${contents}'`);
+  }
+
+  return stripVPrefix(nodeVersion);
+}
+
+function findLatestLts(
+  nodeVersions: INodeVersion[],
+  codename: string
+): INodeVersion {
+  let nodeVersion: INodeVersion | undefined;
+
+  if (codename === 'lts/*') {
+    nodeVersion = nodeVersions.reduce((latest, nodeVersion) => {
+      if (!nodeVersion.lts) {
+        return latest;
+      }
+
+      return semvar.gt(nodeVersion.version, latest.version)
+        ? nodeVersion
+        : latest;
+    });
+  } else {
+    codename = codename.replace('lts/', '').toLowerCase();
+
+    nodeVersion = nodeVersions.find(
+      nodeVersion => `${nodeVersion.lts}`.toLowerCase() === codename
+    );
+  }
+
+  if (!nodeVersion) {
+    throw new Error(
+      `Couldn't find matching release for codename: '${codename}'`
+    );
+  }
+
+  return nodeVersion;
+}
+
+function isPartialMatch(version: string): boolean {
+  return /^\d+(\.\d+(\.\d+)?)?$/.test(version);
+}
+
+function stripVPrefix(version: string): string {
+  return /^v\d/.test(version) ? version.substring(1) : version;
+}

--- a/src/node-version.ts
+++ b/src/node-version.ts
@@ -1,0 +1,21 @@
+import * as hc from '@actions/http-client';
+
+//
+// Node versions interface
+// see https://nodejs.org/dist/index.json
+//
+export interface INodeVersion {
+  version: string;
+  files: string[];
+  lts: boolean | string;
+}
+
+export async function getVersionsFromDist(): Promise<INodeVersion[]> {
+  let dataUrl = 'https://nodejs.org/dist/index.json';
+  let httpClient = new hc.HttpClient('setup-node', [], {
+    allowRetries: true,
+    maxRetries: 3
+  });
+  let response = await httpClient.getJson<INodeVersion[]>(dataUrl);
+  return response.result || [];
+}


### PR DESCRIPTION
### Overview

Implemented the ability to define a file within a project as the holder of the projects node version such as an `.nvmrc` file so to mitigate duplicating node version declarations. After recently researching the ability to do this I came across this ["issue"](https://github.com/actions/setup-node/issues/32) (albeit not an issue) and then came across this [comment](https://github.com/actions/setup-node/issues/32#issuecomment-522083355) which is the implementation I had envisaged.

The implementation follows a similar flow as defined in the comment whereby the `node-version` input takes precedence and if not provided and the `node-version-file` input is, then read the provided node version file.

### Commits

- Implemented support for repository defined node version files such as '.nvmrc'