### PR TITLE
fix(docs): setup-node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Check latest version:
 ```yaml
 steps:
 - uses: actions/checkout@v2
-- uses: actions/setup-node@v2
+- uses: actions/setup-node@v1
   with:
     node-version: '12'
     check-latest: true

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Check latest version:
 ```yaml
 steps:
 - uses: actions/checkout@v2
-- uses: actions/setup-node@v1
+- uses: actions/setup-node@v2-beta
   with:
     node-version: '12'
     check-latest: true


### PR DESCRIPTION
Version v2 not exists yet
```
Error: Unable to resolve action `actions/setup-node@v2`, unable to find version `v2`
```