### PR TITLE
Read version from .nvmrc or .tool-versions config

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4695,6 +4695,7 @@ const auth = __importStar(__webpack_require__(202));
 const path = __importStar(__webpack_require__(622));
 const url_1 = __webpack_require__(835);
 const os = __webpack_require__(87);
+const fs = __webpack_require__(747);
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -4702,10 +4703,7 @@ function run() {
             // Version is optional.  If supplied, install / use from the tool cache
             // If not supplied then task is still used to setup proxy, auth, etc...
             //
-            let version = core.getInput('node-version');
-            if (!version) {
-                version = core.getInput('version');
-            }
+            let version = parseNodeVersion();
             let arch = core.getInput('architecture');
             // if architecture supplied but node-version is not
             // if we don't throw a warning, the already installed x64 node will be used which is not probably what user meant.
@@ -4741,6 +4739,29 @@ exports.run = run;
 function isGhes() {
     const ghUrl = new url_1.URL(process.env['GITHUB_SERVER_URL'] || 'https://github.com');
     return ghUrl.hostname.toUpperCase() !== 'GITHUB.COM';
+}
+function parseNodeVersion() {
+    let nodeVersion = core.getInput('node-version') || core.getInput('version');
+    if (!nodeVersion) {
+        if (fs.existsSync('.nvmrc')) {
+            // Read from .nvmrc
+            nodeVersion = fs.readFileSync('.nvmrc', 'utf8').trim();
+            console.log(`Using ${nodeVersion} as input from file .nvmrc`);
+        }
+        else if (fs.existsSync('.tool-versions')) {
+            // Read from .tool-versions
+            const toolVersions = fs.readFileSync('.tool-versions', 'utf8').trim();
+            const nodeLine = toolVersions
+                .split(/\r?\n/)
+                .filter(e => e.match(/^nodejs\s/))[0];
+            nodeVersion = nodeLine.match(/^nodejs\s+(.+)$/)[1];
+            console.log(`Using ${nodeVersion} as input from file .tool-versions`);
+        }
+        else {
+            console.log(`Version not specified and not found in .nvmrc or .tool-versions`);
+        }
+    }
+    return nodeVersion;
 }
 //# sourceMappingURL=main.js.map
 


### PR DESCRIPTION
[NVM](https://github.com/nvm-sh/nvm) and [asdf](https://github.com/asdf-vm/asdf) are popular tools for managing node (and other dependency) versions in projects. These tools provide the ability to specify the version number in either a `.nvmrc` or `.tool-versions` file and have the management tool automatically install and configure that version.

This patch (shamelessly plagiarised and adapted from [setup-ruby](https://github.com/ruby/setup-ruby)) will attempt to set the version from the `.nvmrc` or `.tool-versions` file if not specified explicitly. If it is unable to find and parse a version then it will return a blank string and fallback to the original logic to use the architecture's pre-installed node.

To be clear, the order of precedence is:

1. Use the version explicitly set in the `version` or `node-version` option,
2. Attempt to read the version from `.nvmrc` if the file is present,
3. Attempt to read the version from `.tool-versions` if the file is present,
4. Fallback to the system node.

By enabling the action to read from these common configuration files we reduce coupling and allow developers to manage their node version from a single location within their codebase.

This patch provides the enhancement discussed in #32 .

Finally, this is the first time that I've worked with Typescript (I'm a rubyist at heart) so I'm open to code review and suggestions to improve the code itself.

Happy New Year! 🎉
