### PR TITLE
Support LTS aliases

### DIFF
--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -42,9 +42,6 @@ jobs:
         uses: ./
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Verify node and npm
-        run: __tests__/verify-node.sh "${{ matrix.node-version }}"
-        shell: bash
 
   manifest:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -29,6 +29,23 @@ jobs:
         run: __tests__/verify-node.sh "${{ matrix.node-version }}"
         shell: bash
 
+  lts-syntax:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: [lts/dubnium, lts/erbium, lts/fermium, lts/*]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node
+        uses: ./
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Verify node and npm
+        run: __tests__/verify-node.sh "${{ matrix.node-version }}"
+        shell: bash
+
   manifest:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/__tests__/data/versions-manifest.json
+++ b/__tests__/data/versions-manifest.json
@@ -2,6 +2,7 @@
     {
       "version": "14.0.0",
       "stable": true,
+      "lts": "Fermium",
       "release_url": "https://github.com/actions/node-versions/releases/tag/14.0.0-20200423.30",
       "files": [
         {
@@ -52,6 +53,7 @@
     {
       "version": "12.16.2",
       "stable": true,
+      "lts": "Erbium",
       "release_url": "https://github.com/actions/node-versions/releases/tag/12.16.2-20200423.28",
       "files": [
         {
@@ -77,6 +79,7 @@
     {
       "version": "10.20.1",
       "stable": true,
+      "lts": "Dubnium",
       "release_url": "https://github.com/actions/node-versions/releases/tag/10.20.1-20200423.27",
       "files": [
         {
@@ -102,6 +105,7 @@
     {
       "version": "8.17.0",
       "stable": true,
+      "lts": "Carbon",
       "release_url": "https://github.com/actions/node-versions/releases/tag/8.17.0-20200423.26",
       "files": [
         {
@@ -127,6 +131,7 @@
     {
       "version": "6.17.1",
       "stable": true,
+      "lts": "Boron",
       "release_url": "https://github.com/actions/node-versions/releases/tag/6.17.1-20200423.25",
       "files": [
         {

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -399,6 +399,7 @@ describe('setup-node', () => {
       expect(logSpy).not.toHaveBeenCalledWith(
         'Attempt to resolve the latest version from manifest...'
       );
+      expect(dbgSpy).not.toHaveBeenCalledWith('No manifest cached, getting manifest from actions/node-versions@main')
     });
 
     it('check latest version and resolve it from local cache', async () => {
@@ -419,6 +420,7 @@ describe('setup-node', () => {
       expect(logSpy).toHaveBeenCalledWith(
         'Attempt to resolve the latest version from manifest...'
       );
+      expect(dbgSpy).toHaveBeenCalledWith('No manifest cached, getting manifest from actions/node-versions@main')
       expect(logSpy).toHaveBeenCalledWith("Resolved as '12.16.2'");
       expect(logSpy).toHaveBeenCalledWith(`Found in cache @ ${toolPath}`);
     });
@@ -443,6 +445,7 @@ describe('setup-node', () => {
       expect(logSpy).toHaveBeenCalledWith(
         'Attempt to resolve the latest version from manifest...'
       );
+      expect(dbgSpy).toHaveBeenCalledWith('No manifest cached, getting manifest from actions/node-versions@main')
       expect(logSpy).toHaveBeenCalledWith("Resolved as '12.16.2'");
       expect(logSpy).toHaveBeenCalledWith(
         `Acquiring 12.16.2 - ${os.arch} from ${expectedUrl}`
@@ -479,6 +482,7 @@ describe('setup-node', () => {
       expect(logSpy).toHaveBeenCalledWith(
         'Attempt to resolve the latest version from manifest...'
       );
+      expect(dbgSpy).toHaveBeenCalledWith('No manifest cached, getting manifest from actions/node-versions@main')
       expect(logSpy).toHaveBeenCalledWith(
         `Failed to resolve version ${versionSpec} from manifest`
       );
@@ -522,6 +526,7 @@ describe('setup-node', () => {
       );
       expect(logSpy).toHaveBeenCalledWith(
         'Unable to resolve version from manifest...'
+        // 'Unable to get manifest...'
       );
       expect(logSpy).toHaveBeenCalledWith(
         `Failed to resolve version ${versionSpec} from manifest`
@@ -549,11 +554,11 @@ describe('setup-node', () => {
       await main.run();
 
       // assert
-      expect(logSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
-      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
+      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve LTS alias from manifest...')
+      expect(dbgSpy).toHaveBeenCalledWith('Getting manifest from actions/node-versions@main')
+      expect(dbgSpy).not.toHaveBeenCalledWith('No manifest cached, getting manifest from actions/node-versions@main')
       expect(dbgSpy).toHaveBeenCalledWith(`LTS alias 'erbium' for Node version 'lts/erbium'`)
       expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release '12.16.2' for Node version 'lts/erbium'`)
-      expect(logSpy).toHaveBeenCalledWith("Resolved as '12.16.2'");
       expect(logSpy).toHaveBeenCalledWith(`Found in cache @ ${toolPath}`);
       expect(cnSpy).toHaveBeenCalledWith(`::add-path::${toolPath}/bin${osm.EOL}`);
     });
@@ -577,12 +582,12 @@ describe('setup-node', () => {
       await main.run();
 
       // assert
-      expect(logSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
-      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
+      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve LTS alias from manifest...')
+      expect(dbgSpy).toHaveBeenCalledWith('Getting manifest from actions/node-versions@main')
+      expect(dbgSpy).not.toHaveBeenCalledWith('No manifest cached, getting manifest from actions/node-versions@main')
       expect(dbgSpy).toHaveBeenCalledWith(`LTS alias 'erbium' for Node version 'lts/erbium'`)
       expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release '12.16.2' for Node version 'lts/erbium'`)
-      expect(logSpy).toHaveBeenCalledWith("Resolved as '12.16.2'");
-      expect(logSpy).toHaveBeenCalledWith("Attempting to download 12.16.2...");
+      expect(logSpy).toHaveBeenCalledWith("Attempting to download 12...");
       expect(logSpy).toHaveBeenCalledWith(`Acquiring 12.16.2 - ${os.arch} from ${expectedUrl}`);
       expect(logSpy).toHaveBeenCalledWith('Extracting ...');
       expect(logSpy).toHaveBeenCalledWith('Adding to the cache ...');
@@ -604,11 +609,11 @@ describe('setup-node', () => {
       await main.run();
 
       // assert
-      expect(logSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
-      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
+      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve LTS alias from manifest...')
+      expect(dbgSpy).toHaveBeenCalledWith('Getting manifest from actions/node-versions@main')
+      expect(dbgSpy).not.toHaveBeenCalledWith('No manifest cached, getting manifest from actions/node-versions@main')
       expect(dbgSpy).toHaveBeenCalledWith(`LTS alias '*' for Node version 'lts/*'`)
       expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release '14.0.0' for Node version 'lts/*'`)
-      expect(logSpy).toHaveBeenCalledWith("Resolved as '14.0.0'");
       expect(logSpy).toHaveBeenCalledWith(`Found in cache @ ${toolPath}`);
       expect(cnSpy).toHaveBeenCalledWith(`::add-path::${toolPath}/bin${osm.EOL}`);
     });
@@ -632,12 +637,12 @@ describe('setup-node', () => {
       await main.run();
 
       // assert
-      expect(logSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
-      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
+      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve LTS alias from manifest...')
+      expect(dbgSpy).toHaveBeenCalledWith('Getting manifest from actions/node-versions@main')
+      expect(dbgSpy).not.toHaveBeenCalledWith('No manifest cached, getting manifest from actions/node-versions@main')
       expect(dbgSpy).toHaveBeenCalledWith(`LTS alias '*' for Node version 'lts/*'`)
       expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release '14.0.0' for Node version 'lts/*'`)
-      expect(logSpy).toHaveBeenCalledWith("Resolved as '14.0.0'");
-      expect(logSpy).toHaveBeenCalledWith("Attempting to download 14.0.0...");
+      expect(logSpy).toHaveBeenCalledWith("Attempting to download 14...");
       expect(logSpy).toHaveBeenCalledWith(`Acquiring 14.0.0 - ${os.arch} from ${expectedUrl}`);
       expect(logSpy).toHaveBeenCalledWith('Extracting ...');
       expect(logSpy).toHaveBeenCalledWith('Adding to the cache ...');
@@ -658,12 +663,9 @@ describe('setup-node', () => {
       await main.run();
 
       // assert
-      expect(logSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
-      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
-      expect(logSpy).toHaveBeenCalledWith('Unable to resolve version from manifest...');
-      expect(dbgSpy).toHaveBeenCalledWith(`Unexpected LTS alias '' for Node version 'lts/'`)
-      expect(logSpy).toHaveBeenCalledWith('Failed to resolve version lts/ from manifest');
-      expect(cnSpy).toHaveBeenCalledWith(`::error::Unable to find Node version 'lts/' for platform linux and architecture x64.${osm.EOL}`);
+      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve LTS alias from manifest...')
+      expect(dbgSpy).toHaveBeenCalledWith('Getting manifest from actions/node-versions@main')
+      expect(cnSpy).toHaveBeenCalledWith(`::error::Unexpected LTS alias '' for Node version 'lts/'${osm.EOL}`)
     });
 
     it('fail to find LTS version (lts/unknown)', async () => {
@@ -680,13 +682,33 @@ describe('setup-node', () => {
       await main.run();
 
       // assert
-      expect(logSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
-      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
+      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve LTS alias from manifest...')
+      expect(dbgSpy).toHaveBeenCalledWith('Getting manifest from actions/node-versions@main')
       expect(dbgSpy).toHaveBeenCalledWith(`LTS alias 'unknown' for Node version 'lts/unknown'`)
-      expect(logSpy).toHaveBeenCalledWith('Unable to resolve version from manifest...');
-      expect(dbgSpy).toHaveBeenCalledWith(`Unable to find LTS release 'unknown' for Node version 'lts/unknown'.`)
-      expect(logSpy).toHaveBeenCalledWith('Failed to resolve version lts/unknown from manifest');
-      expect(cnSpy).toHaveBeenCalledWith(`::error::Unable to find Node version 'lts/unknown' for platform linux and architecture x64.${osm.EOL}`);
+      expect(cnSpy).toHaveBeenCalledWith(`::error::Unable to find LTS release 'unknown' for Node version 'lts/unknown'.${osm.EOL}`)
     });
+
+    it('fail if manifest is not available', async () => {
+      // arrange
+      os.platform = 'linux';
+      os.arch = 'x64';
+
+      inputs['node-version'] = 'lts/erbium';
+      inputs.stable = 'true';
+
+      // ... but not in the local cache
+      findSpy.mockImplementation(() => '');
+      getManifestSpy.mockImplementation(() => {
+        throw new Error('Unable to download manifest');
+      });
+
+      // act
+      await main.run();
+
+      // assert
+      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve LTS alias from manifest...')
+      expect(dbgSpy).toHaveBeenCalledWith('Getting manifest from actions/node-versions@main')
+      expect(cnSpy).toHaveBeenCalledWith(`::error::Unable to download manifest${osm.EOL}`)
+    })
   })
 });

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -399,8 +399,9 @@ describe('setup-node', () => {
       expect(logSpy).not.toHaveBeenCalledWith(
         'Attempt to resolve the latest version from manifest...'
       );
+      expect(dbgSpy).not.toHaveBeenCalledWith('No manifest cached');
       expect(dbgSpy).not.toHaveBeenCalledWith(
-        'No manifest cached, getting manifest from actions/node-versions@main'
+        'Getting manifest from actions/node-versions@main'
       );
     });
 
@@ -422,8 +423,9 @@ describe('setup-node', () => {
       expect(logSpy).toHaveBeenCalledWith(
         'Attempt to resolve the latest version from manifest...'
       );
+      expect(dbgSpy).toHaveBeenCalledWith('No manifest cached');
       expect(dbgSpy).toHaveBeenCalledWith(
-        'No manifest cached, getting manifest from actions/node-versions@main'
+        'Getting manifest from actions/node-versions@main'
       );
       expect(logSpy).toHaveBeenCalledWith("Resolved as '12.16.2'");
       expect(logSpy).toHaveBeenCalledWith(`Found in cache @ ${toolPath}`);
@@ -449,8 +451,9 @@ describe('setup-node', () => {
       expect(logSpy).toHaveBeenCalledWith(
         'Attempt to resolve the latest version from manifest...'
       );
+      expect(dbgSpy).toHaveBeenCalledWith('No manifest cached');
       expect(dbgSpy).toHaveBeenCalledWith(
-        'No manifest cached, getting manifest from actions/node-versions@main'
+        'Getting manifest from actions/node-versions@main'
       );
       expect(logSpy).toHaveBeenCalledWith("Resolved as '12.16.2'");
       expect(logSpy).toHaveBeenCalledWith(
@@ -488,8 +491,9 @@ describe('setup-node', () => {
       expect(logSpy).toHaveBeenCalledWith(
         'Attempt to resolve the latest version from manifest...'
       );
+      expect(dbgSpy).toHaveBeenCalledWith('No manifest cached');
       expect(dbgSpy).toHaveBeenCalledWith(
-        'No manifest cached, getting manifest from actions/node-versions@main'
+        'Getting manifest from actions/node-versions@main'
       );
       expect(logSpy).toHaveBeenCalledWith(
         `Failed to resolve version ${versionSpec} from manifest`
@@ -567,9 +571,7 @@ describe('setup-node', () => {
       expect(dbgSpy).toHaveBeenCalledWith(
         'Getting manifest from actions/node-versions@main'
       );
-      expect(dbgSpy).not.toHaveBeenCalledWith(
-        'No manifest cached, getting manifest from actions/node-versions@main'
-      );
+      expect(dbgSpy).not.toHaveBeenCalledWith('No manifest cached');
       expect(dbgSpy).toHaveBeenCalledWith(
         `LTS alias 'erbium' for Node version 'lts/erbium'`
       );
@@ -608,9 +610,7 @@ describe('setup-node', () => {
       expect(dbgSpy).toHaveBeenCalledWith(
         'Getting manifest from actions/node-versions@main'
       );
-      expect(dbgSpy).not.toHaveBeenCalledWith(
-        'No manifest cached, getting manifest from actions/node-versions@main'
-      );
+      expect(dbgSpy).not.toHaveBeenCalledWith('No manifest cached');
       expect(dbgSpy).toHaveBeenCalledWith(
         `LTS alias 'erbium' for Node version 'lts/erbium'`
       );
@@ -649,9 +649,7 @@ describe('setup-node', () => {
       expect(dbgSpy).toHaveBeenCalledWith(
         'Getting manifest from actions/node-versions@main'
       );
-      expect(dbgSpy).not.toHaveBeenCalledWith(
-        'No manifest cached, getting manifest from actions/node-versions@main'
-      );
+      expect(dbgSpy).not.toHaveBeenCalledWith('No manifest cached');
       expect(dbgSpy).toHaveBeenCalledWith(
         `LTS alias '*' for Node version 'lts/*'`
       );
@@ -690,9 +688,7 @@ describe('setup-node', () => {
       expect(dbgSpy).toHaveBeenCalledWith(
         'Getting manifest from actions/node-versions@main'
       );
-      expect(dbgSpy).not.toHaveBeenCalledWith(
-        'No manifest cached, getting manifest from actions/node-versions@main'
-      );
+      expect(dbgSpy).not.toHaveBeenCalledWith('No manifest cached');
       expect(dbgSpy).toHaveBeenCalledWith(
         `LTS alias '*' for Node version 'lts/*'`
       );

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -696,7 +696,7 @@ describe('setup-node', () => {
       );
     });
 
-    it('fail with unexpected LTS alias (lts/)', async () => {
+    it('fail with unable to parse LTS alias (lts/)', async () => {
       // arrange
       inputs['node-version'] = 'lts/';
 
@@ -713,7 +713,7 @@ describe('setup-node', () => {
         'Getting manifest from actions/node-versions@main'
       );
       expect(cnSpy).toHaveBeenCalledWith(
-        `::error::Unexpected LTS alias '' for Node version 'lts/'${osm.EOL}`
+        `::error::Unable to parse LTS alias for Node version 'lts/'${osm.EOL}`
       );
     });
 

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -549,8 +549,8 @@ describe('setup-node', () => {
       await main.run();
 
       // assert
-      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
       expect(warningSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
+      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
       expect(dbgSpy).toHaveBeenCalledWith(`LTS alias 'erbium' for Node version 'lts/erbium'`)
       expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release '12.16.2' for Node version 'lts/erbium'`)
       expect(logSpy).toHaveBeenCalledWith("Resolved as '12.16.2'");
@@ -577,8 +577,8 @@ describe('setup-node', () => {
       await main.run();
 
       // assert
-      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
       expect(warningSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
+      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
       expect(dbgSpy).toHaveBeenCalledWith(`LTS alias 'erbium' for Node version 'lts/erbium'`)
       expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release '12.16.2' for Node version 'lts/erbium'`)
       expect(logSpy).toHaveBeenCalledWith("Resolved as '12.16.2'");
@@ -604,8 +604,8 @@ describe('setup-node', () => {
       await main.run();
 
       // assert
-      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
       expect(warningSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
+      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
       expect(dbgSpy).toHaveBeenCalledWith(`LTS alias '*' for Node version 'lts/*'`)
       expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release '14.0.0' for Node version 'lts/*'`)
       expect(logSpy).toHaveBeenCalledWith("Resolved as '14.0.0'");
@@ -632,8 +632,8 @@ describe('setup-node', () => {
       await main.run();
 
       // assert
-      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
       expect(warningSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
+      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
       expect(dbgSpy).toHaveBeenCalledWith(`LTS alias '*' for Node version 'lts/*'`)
       expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release '14.0.0' for Node version 'lts/*'`)
       expect(logSpy).toHaveBeenCalledWith("Resolved as '14.0.0'");
@@ -643,5 +643,50 @@ describe('setup-node', () => {
       expect(logSpy).toHaveBeenCalledWith('Adding to the cache ...');
       expect(cnSpy).toHaveBeenCalledWith(`::add-path::${toolPath}/bin${osm.EOL}`);
     })
+
+    it('fail with unexpected LTS alias (lts/)', async () => {
+      // arrange
+      os.platform = 'linux';
+      os.arch = 'x64';
+
+      inputs['node-version'] = 'lts/';
+      inputs.stable = 'true';
+
+      findSpy.mockImplementation(() => '');
+
+      // act
+      await main.run();
+
+      // assert
+      expect(warningSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
+      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
+      expect(logSpy).toHaveBeenCalledWith('Unable to resolve version from manifest...');
+      expect(dbgSpy).toHaveBeenCalledWith(`Unexpected LTS alias '' for Node version 'lts/'`)
+      expect(logSpy).toHaveBeenCalledWith('Failed to resolve version lts/ from manifest');
+      expect(cnSpy).toHaveBeenCalledWith(`::error::Unable to find Node version 'lts/' for platform linux and architecture x64.${osm.EOL}`);
+    });
+
+    it('fail to find LTS version (lts/unknown)', async () => {
+      // arrange
+      os.platform = 'linux';
+      os.arch = 'x64';
+
+      inputs['node-version'] = 'lts/unknown';
+      inputs.stable = 'true';
+
+      findSpy.mockImplementation(() => '');
+
+      // act
+      await main.run();
+
+      // assert
+      expect(warningSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
+      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
+      expect(dbgSpy).toHaveBeenCalledWith(`LTS alias 'unknown' for Node version 'lts/unknown'`)
+      expect(logSpy).toHaveBeenCalledWith('Unable to resolve version from manifest...');
+      expect(dbgSpy).toHaveBeenCalledWith(`Unable to find LTS release 'unknown' for Node version 'lts/unknown'.`)
+      expect(logSpy).toHaveBeenCalledWith('Failed to resolve version lts/unknown from manifest');
+      expect(cnSpy).toHaveBeenCalledWith(`::error::Unable to find Node version 'lts/unknown' for platform linux and architecture x64.${osm.EOL}`);
+    });
   })
 });

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -552,7 +552,7 @@ describe('setup-node', () => {
       expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
       expect(warningSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
       expect(dbgSpy).toHaveBeenCalledWith(`LTS alias 'erbium' for Node version 'lts/erbium'`)
-      expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release 'erbium' for Node version 'lts/erbium'`)
+      expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release '12.16.2' for Node version 'lts/erbium'`)
       expect(logSpy).toHaveBeenCalledWith("Resolved as '12.16.2'");
       expect(logSpy).toHaveBeenCalledWith(`Found in cache @ ${toolPath}`);
       expect(cnSpy).toHaveBeenCalledWith(`::add-path::${toolPath}/bin${osm.EOL}`);
@@ -580,10 +580,65 @@ describe('setup-node', () => {
       expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
       expect(warningSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
       expect(dbgSpy).toHaveBeenCalledWith(`LTS alias 'erbium' for Node version 'lts/erbium'`)
-      expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release 'erbium' for Node version 'lts/erbium'`)
+      expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release '12.16.2' for Node version 'lts/erbium'`)
       expect(logSpy).toHaveBeenCalledWith("Resolved as '12.16.2'");
       expect(logSpy).toHaveBeenCalledWith("Attempting to download 12.16.2...");
       expect(logSpy).toHaveBeenCalledWith(`Acquiring 12.16.2 - ${os.arch} from ${expectedUrl}`);
+      expect(logSpy).toHaveBeenCalledWith('Extracting ...');
+      expect(logSpy).toHaveBeenCalledWith('Adding to the cache ...');
+      expect(cnSpy).toHaveBeenCalledWith(`::add-path::${toolPath}/bin${osm.EOL}`);
+    })
+
+    it('find latest LTS version and resolve it from local cache (lts/*)', async () => {
+      // arrange
+      os.platform = 'linux';
+      os.arch = 'x64';
+
+      inputs['node-version'] = 'lts/*';
+      inputs.stable = 'true';
+
+      const toolPath = path.normalize('/cache/node/14.0.0/x64');
+      findSpy.mockReturnValue(toolPath);
+
+      // act
+      await main.run();
+
+      // assert
+      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
+      expect(warningSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
+      expect(dbgSpy).toHaveBeenCalledWith(`LTS alias '*' for Node version 'lts/*'`)
+      expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release '14.0.0' for Node version 'lts/*'`)
+      expect(logSpy).toHaveBeenCalledWith("Resolved as '14.0.0'");
+      expect(logSpy).toHaveBeenCalledWith(`Found in cache @ ${toolPath}`);
+      expect(cnSpy).toHaveBeenCalledWith(`::add-path::${toolPath}/bin${osm.EOL}`);
+    });
+
+    it('find latest LTS version and install it from manifest (lts/*)', async () => {
+      // arrange
+      os.platform = 'linux';
+      os.arch = 'x64';
+
+      inputs['node-version'] = 'lts/*';
+      inputs.stable = 'true';
+
+      const toolPath = path.normalize('/cache/node/14.0.0/x64');
+      findSpy.mockImplementation(() => '');
+      dlSpy.mockImplementation(async () => '/some/temp/path');
+      exSpy.mockImplementation(async () => '/some/other/temp/path');
+      cacheSpy.mockImplementation(async () => toolPath);
+      const expectedUrl = 'https://github.com/actions/node-versions/releases/download/14.0.0-20200423.30/node-14.0.0-linux-x64.tar.gz';
+
+      // act
+      await main.run();
+
+      // assert
+      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
+      expect(warningSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
+      expect(dbgSpy).toHaveBeenCalledWith(`LTS alias '*' for Node version 'lts/*'`)
+      expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release '14.0.0' for Node version 'lts/*'`)
+      expect(logSpy).toHaveBeenCalledWith("Resolved as '14.0.0'");
+      expect(logSpy).toHaveBeenCalledWith("Attempting to download 14.0.0...");
+      expect(logSpy).toHaveBeenCalledWith(`Acquiring 14.0.0 - ${os.arch} from ${expectedUrl}`);
       expect(logSpy).toHaveBeenCalledWith('Extracting ...');
       expect(logSpy).toHaveBeenCalledWith('Adding to the cache ...');
       expect(cnSpy).toHaveBeenCalledWith(`::add-path::${toolPath}/bin${osm.EOL}`);

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -549,7 +549,7 @@ describe('setup-node', () => {
       await main.run();
 
       // assert
-      expect(warningSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
+      expect(logSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
       expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
       expect(dbgSpy).toHaveBeenCalledWith(`LTS alias 'erbium' for Node version 'lts/erbium'`)
       expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release '12.16.2' for Node version 'lts/erbium'`)
@@ -577,7 +577,7 @@ describe('setup-node', () => {
       await main.run();
 
       // assert
-      expect(warningSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
+      expect(logSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
       expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
       expect(dbgSpy).toHaveBeenCalledWith(`LTS alias 'erbium' for Node version 'lts/erbium'`)
       expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release '12.16.2' for Node version 'lts/erbium'`)
@@ -604,7 +604,7 @@ describe('setup-node', () => {
       await main.run();
 
       // assert
-      expect(warningSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
+      expect(logSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
       expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
       expect(dbgSpy).toHaveBeenCalledWith(`LTS alias '*' for Node version 'lts/*'`)
       expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release '14.0.0' for Node version 'lts/*'`)
@@ -632,7 +632,7 @@ describe('setup-node', () => {
       await main.run();
 
       // assert
-      expect(warningSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
+      expect(logSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
       expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
       expect(dbgSpy).toHaveBeenCalledWith(`LTS alias '*' for Node version 'lts/*'`)
       expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release '14.0.0' for Node version 'lts/*'`)
@@ -658,7 +658,7 @@ describe('setup-node', () => {
       await main.run();
 
       // assert
-      expect(warningSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
+      expect(logSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
       expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
       expect(logSpy).toHaveBeenCalledWith('Unable to resolve version from manifest...');
       expect(dbgSpy).toHaveBeenCalledWith(`Unexpected LTS alias '' for Node version 'lts/'`)
@@ -680,7 +680,7 @@ describe('setup-node', () => {
       await main.run();
 
       // assert
-      expect(warningSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
+      expect(logSpy).toHaveBeenCalledWith('LTS version is provided. For LTS versions `check-latest` will be automatically set to true')
       expect(logSpy).toHaveBeenCalledWith('Attempt to resolve the latest version from manifest...');
       expect(dbgSpy).toHaveBeenCalledWith(`LTS alias 'unknown' for Node version 'lts/unknown'`)
       expect(logSpy).toHaveBeenCalledWith('Unable to resolve version from manifest...');

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -550,13 +550,15 @@ describe('setup-node', () => {
   });
 
   describe('LTS version', () => {
-    it('find latest LTS version and resolve it from local cache (lts/erbium)', async () => {
-      // arrange
+    beforeEach(() => {
       os.platform = 'linux';
       os.arch = 'x64';
-
-      inputs['node-version'] = 'lts/erbium';
       inputs.stable = 'true';
+    });
+
+    it('find latest LTS version and resolve it from local cache (lts/erbium)', async () => {
+      // arrange
+      inputs['node-version'] = 'lts/erbium';
 
       const toolPath = path.normalize('/cache/node/12.16.2/x64');
       findSpy.mockReturnValue(toolPath);
@@ -586,11 +588,7 @@ describe('setup-node', () => {
 
     it('find latest LTS version and install it from manifest (lts/erbium)', async () => {
       // arrange
-      os.platform = 'linux';
-      os.arch = 'x64';
-
       inputs['node-version'] = 'lts/erbium';
-      inputs.stable = 'true';
 
       const toolPath = path.normalize('/cache/node/12.16.2/x64');
       findSpy.mockImplementation(() => '');
@@ -630,11 +628,7 @@ describe('setup-node', () => {
 
     it('find latest LTS version and resolve it from local cache (lts/*)', async () => {
       // arrange
-      os.platform = 'linux';
-      os.arch = 'x64';
-
       inputs['node-version'] = 'lts/*';
-      inputs.stable = 'true';
 
       const toolPath = path.normalize('/cache/node/14.0.0/x64');
       findSpy.mockReturnValue(toolPath);
@@ -664,11 +658,7 @@ describe('setup-node', () => {
 
     it('find latest LTS version and install it from manifest (lts/*)', async () => {
       // arrange
-      os.platform = 'linux';
-      os.arch = 'x64';
-
       inputs['node-version'] = 'lts/*';
-      inputs.stable = 'true';
 
       const toolPath = path.normalize('/cache/node/14.0.0/x64');
       findSpy.mockImplementation(() => '');
@@ -708,11 +698,7 @@ describe('setup-node', () => {
 
     it('fail with unexpected LTS alias (lts/)', async () => {
       // arrange
-      os.platform = 'linux';
-      os.arch = 'x64';
-
       inputs['node-version'] = 'lts/';
-      inputs.stable = 'true';
 
       findSpy.mockImplementation(() => '');
 
@@ -733,11 +719,7 @@ describe('setup-node', () => {
 
     it('fail to find LTS version (lts/unknown)', async () => {
       // arrange
-      os.platform = 'linux';
-      os.arch = 'x64';
-
       inputs['node-version'] = 'lts/unknown';
-      inputs.stable = 'true';
 
       findSpy.mockImplementation(() => '');
 
@@ -761,11 +743,7 @@ describe('setup-node', () => {
 
     it('fail if manifest is not available', async () => {
       // arrange
-      os.platform = 'linux';
-      os.arch = 'x64';
-
       inputs['node-version'] = 'lts/erbium';
-      inputs.stable = 'true';
 
       // ... but not in the local cache
       findSpy.mockImplementation(() => '');

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -134,7 +134,7 @@ describe('setup-node', () => {
     let match = await tc.findFromManifest('12.16.2', true, versions);
     expect(match).toBeDefined();
     expect(match?.version).toBe('12.16.2');
-    expect((match as any).lts).toBe('Erbium')
+    expect((match as any).lts).toBe('Erbium');
   });
 
   it('can find 12 from manifest on linux', async () => {
@@ -149,7 +149,7 @@ describe('setup-node', () => {
     let match = await tc.findFromManifest('12.16.2', true, versions);
     expect(match).toBeDefined();
     expect(match?.version).toBe('12.16.2');
-    expect((match as any).lts).toBe('Erbium')
+    expect((match as any).lts).toBe('Erbium');
   });
 
   it('can find 10 from manifest on windows', async () => {
@@ -164,7 +164,7 @@ describe('setup-node', () => {
     let match = await tc.findFromManifest('10', true, versions);
     expect(match).toBeDefined();
     expect(match?.version).toBe('10.20.1');
-    expect((match as any).lts).toBe('Dubnium')
+    expect((match as any).lts).toBe('Dubnium');
   });
 
   //--------------------------------------------------
@@ -399,7 +399,9 @@ describe('setup-node', () => {
       expect(logSpy).not.toHaveBeenCalledWith(
         'Attempt to resolve the latest version from manifest...'
       );
-      expect(dbgSpy).not.toHaveBeenCalledWith('No manifest cached, getting manifest from actions/node-versions@main')
+      expect(dbgSpy).not.toHaveBeenCalledWith(
+        'No manifest cached, getting manifest from actions/node-versions@main'
+      );
     });
 
     it('check latest version and resolve it from local cache', async () => {
@@ -420,7 +422,9 @@ describe('setup-node', () => {
       expect(logSpy).toHaveBeenCalledWith(
         'Attempt to resolve the latest version from manifest...'
       );
-      expect(dbgSpy).toHaveBeenCalledWith('No manifest cached, getting manifest from actions/node-versions@main')
+      expect(dbgSpy).toHaveBeenCalledWith(
+        'No manifest cached, getting manifest from actions/node-versions@main'
+      );
       expect(logSpy).toHaveBeenCalledWith("Resolved as '12.16.2'");
       expect(logSpy).toHaveBeenCalledWith(`Found in cache @ ${toolPath}`);
     });
@@ -445,7 +449,9 @@ describe('setup-node', () => {
       expect(logSpy).toHaveBeenCalledWith(
         'Attempt to resolve the latest version from manifest...'
       );
-      expect(dbgSpy).toHaveBeenCalledWith('No manifest cached, getting manifest from actions/node-versions@main')
+      expect(dbgSpy).toHaveBeenCalledWith(
+        'No manifest cached, getting manifest from actions/node-versions@main'
+      );
       expect(logSpy).toHaveBeenCalledWith("Resolved as '12.16.2'");
       expect(logSpy).toHaveBeenCalledWith(
         `Acquiring 12.16.2 - ${os.arch} from ${expectedUrl}`
@@ -482,7 +488,9 @@ describe('setup-node', () => {
       expect(logSpy).toHaveBeenCalledWith(
         'Attempt to resolve the latest version from manifest...'
       );
-      expect(dbgSpy).toHaveBeenCalledWith('No manifest cached, getting manifest from actions/node-versions@main')
+      expect(dbgSpy).toHaveBeenCalledWith(
+        'No manifest cached, getting manifest from actions/node-versions@main'
+      );
       expect(logSpy).toHaveBeenCalledWith(
         `Failed to resolve version ${versionSpec} from manifest`
       );
@@ -553,13 +561,25 @@ describe('setup-node', () => {
       await main.run();
 
       // assert
-      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve LTS alias from manifest...')
-      expect(dbgSpy).toHaveBeenCalledWith('Getting manifest from actions/node-versions@main')
-      expect(dbgSpy).not.toHaveBeenCalledWith('No manifest cached, getting manifest from actions/node-versions@main')
-      expect(dbgSpy).toHaveBeenCalledWith(`LTS alias 'erbium' for Node version 'lts/erbium'`)
-      expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release '12.16.2' for Node version 'lts/erbium'`)
+      expect(logSpy).toHaveBeenCalledWith(
+        'Attempt to resolve LTS alias from manifest...'
+      );
+      expect(dbgSpy).toHaveBeenCalledWith(
+        'Getting manifest from actions/node-versions@main'
+      );
+      expect(dbgSpy).not.toHaveBeenCalledWith(
+        'No manifest cached, getting manifest from actions/node-versions@main'
+      );
+      expect(dbgSpy).toHaveBeenCalledWith(
+        `LTS alias 'erbium' for Node version 'lts/erbium'`
+      );
+      expect(dbgSpy).toHaveBeenCalledWith(
+        `Found LTS release '12.16.2' for Node version 'lts/erbium'`
+      );
       expect(logSpy).toHaveBeenCalledWith(`Found in cache @ ${toolPath}`);
-      expect(cnSpy).toHaveBeenCalledWith(`::add-path::${toolPath}/bin${osm.EOL}`);
+      expect(cnSpy).toHaveBeenCalledWith(
+        `::add-path::${toolPath}/bin${osm.EOL}`
+      );
     });
 
     it('find latest LTS version and install it from manifest (lts/erbium)', async () => {
@@ -575,23 +595,38 @@ describe('setup-node', () => {
       dlSpy.mockImplementation(async () => '/some/temp/path');
       exSpy.mockImplementation(async () => '/some/other/temp/path');
       cacheSpy.mockImplementation(async () => toolPath);
-      const expectedUrl = 'https://github.com/actions/node-versions/releases/download/12.16.2-20200423.28/node-12.16.2-linux-x64.tar.gz';
+      const expectedUrl =
+        'https://github.com/actions/node-versions/releases/download/12.16.2-20200423.28/node-12.16.2-linux-x64.tar.gz';
 
       // act
       await main.run();
 
       // assert
-      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve LTS alias from manifest...')
-      expect(dbgSpy).toHaveBeenCalledWith('Getting manifest from actions/node-versions@main')
-      expect(dbgSpy).not.toHaveBeenCalledWith('No manifest cached, getting manifest from actions/node-versions@main')
-      expect(dbgSpy).toHaveBeenCalledWith(`LTS alias 'erbium' for Node version 'lts/erbium'`)
-      expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release '12.16.2' for Node version 'lts/erbium'`)
-      expect(logSpy).toHaveBeenCalledWith("Attempting to download 12...");
-      expect(logSpy).toHaveBeenCalledWith(`Acquiring 12.16.2 - ${os.arch} from ${expectedUrl}`);
+      expect(logSpy).toHaveBeenCalledWith(
+        'Attempt to resolve LTS alias from manifest...'
+      );
+      expect(dbgSpy).toHaveBeenCalledWith(
+        'Getting manifest from actions/node-versions@main'
+      );
+      expect(dbgSpy).not.toHaveBeenCalledWith(
+        'No manifest cached, getting manifest from actions/node-versions@main'
+      );
+      expect(dbgSpy).toHaveBeenCalledWith(
+        `LTS alias 'erbium' for Node version 'lts/erbium'`
+      );
+      expect(dbgSpy).toHaveBeenCalledWith(
+        `Found LTS release '12.16.2' for Node version 'lts/erbium'`
+      );
+      expect(logSpy).toHaveBeenCalledWith('Attempting to download 12...');
+      expect(logSpy).toHaveBeenCalledWith(
+        `Acquiring 12.16.2 - ${os.arch} from ${expectedUrl}`
+      );
       expect(logSpy).toHaveBeenCalledWith('Extracting ...');
       expect(logSpy).toHaveBeenCalledWith('Adding to the cache ...');
-      expect(cnSpy).toHaveBeenCalledWith(`::add-path::${toolPath}/bin${osm.EOL}`);
-    })
+      expect(cnSpy).toHaveBeenCalledWith(
+        `::add-path::${toolPath}/bin${osm.EOL}`
+      );
+    });
 
     it('find latest LTS version and resolve it from local cache (lts/*)', async () => {
       // arrange
@@ -608,13 +643,25 @@ describe('setup-node', () => {
       await main.run();
 
       // assert
-      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve LTS alias from manifest...')
-      expect(dbgSpy).toHaveBeenCalledWith('Getting manifest from actions/node-versions@main')
-      expect(dbgSpy).not.toHaveBeenCalledWith('No manifest cached, getting manifest from actions/node-versions@main')
-      expect(dbgSpy).toHaveBeenCalledWith(`LTS alias '*' for Node version 'lts/*'`)
-      expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release '14.0.0' for Node version 'lts/*'`)
+      expect(logSpy).toHaveBeenCalledWith(
+        'Attempt to resolve LTS alias from manifest...'
+      );
+      expect(dbgSpy).toHaveBeenCalledWith(
+        'Getting manifest from actions/node-versions@main'
+      );
+      expect(dbgSpy).not.toHaveBeenCalledWith(
+        'No manifest cached, getting manifest from actions/node-versions@main'
+      );
+      expect(dbgSpy).toHaveBeenCalledWith(
+        `LTS alias '*' for Node version 'lts/*'`
+      );
+      expect(dbgSpy).toHaveBeenCalledWith(
+        `Found LTS release '14.0.0' for Node version 'lts/*'`
+      );
       expect(logSpy).toHaveBeenCalledWith(`Found in cache @ ${toolPath}`);
-      expect(cnSpy).toHaveBeenCalledWith(`::add-path::${toolPath}/bin${osm.EOL}`);
+      expect(cnSpy).toHaveBeenCalledWith(
+        `::add-path::${toolPath}/bin${osm.EOL}`
+      );
     });
 
     it('find latest LTS version and install it from manifest (lts/*)', async () => {
@@ -630,23 +677,38 @@ describe('setup-node', () => {
       dlSpy.mockImplementation(async () => '/some/temp/path');
       exSpy.mockImplementation(async () => '/some/other/temp/path');
       cacheSpy.mockImplementation(async () => toolPath);
-      const expectedUrl = 'https://github.com/actions/node-versions/releases/download/14.0.0-20200423.30/node-14.0.0-linux-x64.tar.gz';
+      const expectedUrl =
+        'https://github.com/actions/node-versions/releases/download/14.0.0-20200423.30/node-14.0.0-linux-x64.tar.gz';
 
       // act
       await main.run();
 
       // assert
-      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve LTS alias from manifest...')
-      expect(dbgSpy).toHaveBeenCalledWith('Getting manifest from actions/node-versions@main')
-      expect(dbgSpy).not.toHaveBeenCalledWith('No manifest cached, getting manifest from actions/node-versions@main')
-      expect(dbgSpy).toHaveBeenCalledWith(`LTS alias '*' for Node version 'lts/*'`)
-      expect(dbgSpy).toHaveBeenCalledWith(`Found LTS release '14.0.0' for Node version 'lts/*'`)
-      expect(logSpy).toHaveBeenCalledWith("Attempting to download 14...");
-      expect(logSpy).toHaveBeenCalledWith(`Acquiring 14.0.0 - ${os.arch} from ${expectedUrl}`);
+      expect(logSpy).toHaveBeenCalledWith(
+        'Attempt to resolve LTS alias from manifest...'
+      );
+      expect(dbgSpy).toHaveBeenCalledWith(
+        'Getting manifest from actions/node-versions@main'
+      );
+      expect(dbgSpy).not.toHaveBeenCalledWith(
+        'No manifest cached, getting manifest from actions/node-versions@main'
+      );
+      expect(dbgSpy).toHaveBeenCalledWith(
+        `LTS alias '*' for Node version 'lts/*'`
+      );
+      expect(dbgSpy).toHaveBeenCalledWith(
+        `Found LTS release '14.0.0' for Node version 'lts/*'`
+      );
+      expect(logSpy).toHaveBeenCalledWith('Attempting to download 14...');
+      expect(logSpy).toHaveBeenCalledWith(
+        `Acquiring 14.0.0 - ${os.arch} from ${expectedUrl}`
+      );
       expect(logSpy).toHaveBeenCalledWith('Extracting ...');
       expect(logSpy).toHaveBeenCalledWith('Adding to the cache ...');
-      expect(cnSpy).toHaveBeenCalledWith(`::add-path::${toolPath}/bin${osm.EOL}`);
-    })
+      expect(cnSpy).toHaveBeenCalledWith(
+        `::add-path::${toolPath}/bin${osm.EOL}`
+      );
+    });
 
     it('fail with unexpected LTS alias (lts/)', async () => {
       // arrange
@@ -662,9 +724,15 @@ describe('setup-node', () => {
       await main.run();
 
       // assert
-      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve LTS alias from manifest...')
-      expect(dbgSpy).toHaveBeenCalledWith('Getting manifest from actions/node-versions@main')
-      expect(cnSpy).toHaveBeenCalledWith(`::error::Unexpected LTS alias '' for Node version 'lts/'${osm.EOL}`)
+      expect(logSpy).toHaveBeenCalledWith(
+        'Attempt to resolve LTS alias from manifest...'
+      );
+      expect(dbgSpy).toHaveBeenCalledWith(
+        'Getting manifest from actions/node-versions@main'
+      );
+      expect(cnSpy).toHaveBeenCalledWith(
+        `::error::Unexpected LTS alias '' for Node version 'lts/'${osm.EOL}`
+      );
     });
 
     it('fail to find LTS version (lts/unknown)', async () => {
@@ -681,10 +749,18 @@ describe('setup-node', () => {
       await main.run();
 
       // assert
-      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve LTS alias from manifest...')
-      expect(dbgSpy).toHaveBeenCalledWith('Getting manifest from actions/node-versions@main')
-      expect(dbgSpy).toHaveBeenCalledWith(`LTS alias 'unknown' for Node version 'lts/unknown'`)
-      expect(cnSpy).toHaveBeenCalledWith(`::error::Unable to find LTS release 'unknown' for Node version 'lts/unknown'.${osm.EOL}`)
+      expect(logSpy).toHaveBeenCalledWith(
+        'Attempt to resolve LTS alias from manifest...'
+      );
+      expect(dbgSpy).toHaveBeenCalledWith(
+        'Getting manifest from actions/node-versions@main'
+      );
+      expect(dbgSpy).toHaveBeenCalledWith(
+        `LTS alias 'unknown' for Node version 'lts/unknown'`
+      );
+      expect(cnSpy).toHaveBeenCalledWith(
+        `::error::Unable to find LTS release 'unknown' for Node version 'lts/unknown'.${osm.EOL}`
+      );
     });
 
     it('fail if manifest is not available', async () => {
@@ -705,9 +781,15 @@ describe('setup-node', () => {
       await main.run();
 
       // assert
-      expect(logSpy).toHaveBeenCalledWith('Attempt to resolve LTS alias from manifest...')
-      expect(dbgSpy).toHaveBeenCalledWith('Getting manifest from actions/node-versions@main')
-      expect(cnSpy).toHaveBeenCalledWith(`::error::Unable to download manifest${osm.EOL}`)
-    })
-  })
+      expect(logSpy).toHaveBeenCalledWith(
+        'Attempt to resolve LTS alias from manifest...'
+      );
+      expect(dbgSpy).toHaveBeenCalledWith(
+        'Getting manifest from actions/node-versions@main'
+      );
+      expect(cnSpy).toHaveBeenCalledWith(
+        `::error::Unable to download manifest${osm.EOL}`
+      );
+    });
+  });
 });

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -526,7 +526,6 @@ describe('setup-node', () => {
       );
       expect(logSpy).toHaveBeenCalledWith(
         'Unable to resolve version from manifest...'
-        // 'Unable to get manifest...'
       );
       expect(logSpy).toHaveBeenCalledWith(
         `Failed to resolve version ${versionSpec} from manifest`

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -580,7 +580,7 @@ describe('setup-node', () => {
       );
       expect(logSpy).toHaveBeenCalledWith(`Found in cache @ ${toolPath}`);
       expect(cnSpy).toHaveBeenCalledWith(
-        `::add-path::${toolPath}/bin${osm.EOL}`
+        `::add-path::${path.join(toolPath, 'bin')}${osm.EOL}`
       );
     });
 
@@ -624,7 +624,7 @@ describe('setup-node', () => {
       expect(logSpy).toHaveBeenCalledWith('Extracting ...');
       expect(logSpy).toHaveBeenCalledWith('Adding to the cache ...');
       expect(cnSpy).toHaveBeenCalledWith(
-        `::add-path::${toolPath}/bin${osm.EOL}`
+        `::add-path::${path.join(toolPath, 'bin')}${osm.EOL}`
       );
     });
 
@@ -658,7 +658,7 @@ describe('setup-node', () => {
       );
       expect(logSpy).toHaveBeenCalledWith(`Found in cache @ ${toolPath}`);
       expect(cnSpy).toHaveBeenCalledWith(
-        `::add-path::${toolPath}/bin${osm.EOL}`
+        `::add-path::${path.join(toolPath, 'bin')}${osm.EOL}`
       );
     });
 
@@ -702,7 +702,7 @@ describe('setup-node', () => {
       expect(logSpy).toHaveBeenCalledWith('Extracting ...');
       expect(logSpy).toHaveBeenCalledWith('Adding to the cache ...');
       expect(cnSpy).toHaveBeenCalledWith(
-        `::add-path::${toolPath}/bin${osm.EOL}`
+        `::add-path::${path.join(toolPath, 'bin')}${osm.EOL}`
       );
     });
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -13108,7 +13108,7 @@ function getNode(versionSpec, stable, checkLatest, auth, arch = os.arch()) {
         let osPlat = os.platform();
         let osArch = translateArchToDistUrl(arch);
         if (isLtsVersion(versionSpec)) {
-            core.warning('LTS version is provided. For LTS versions `check-latest` will be automatically set to true');
+            core.info('LTS version is provided. For LTS versions `check-latest` will be automatically set to true');
             checkLatest = true;
         }
         if (checkLatest) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -13107,7 +13107,7 @@ function getNode(versionSpec, stable, checkLatest, auth, arch = os.arch()) {
     return __awaiter(this, void 0, void 0, function* () {
         let osPlat = os.platform();
         let osArch = translateArchToDistUrl(arch);
-        if (isLtsVersion(versionSpec)) {
+        if (isLtsAlias(versionSpec)) {
             core.info('LTS version is provided. For LTS versions `check-latest` will be automatically set to true');
             checkLatest = true;
         }
@@ -13220,10 +13220,10 @@ function getNode(versionSpec, stable, checkLatest, auth, arch = os.arch()) {
     });
 }
 exports.getNode = getNode;
-function isLtsVersion(versionSpec) {
+function isLtsAlias(versionSpec) {
     return versionSpec.startsWith('lts');
 }
-function findLtsVersionFromManifest(versionSpec, stable, candidates) {
+function resolveLtsAliasFromManifest(versionSpec, stable, manifest) {
     var _a;
     const alias = (_a = versionSpec.split('lts/')[1]) === null || _a === void 0 ? void 0 : _a.toLowerCase();
     if (!alias) {
@@ -13232,8 +13232,8 @@ function findLtsVersionFromManifest(versionSpec, stable, candidates) {
     core.debug(`LTS alias '${alias}' for Node version '${versionSpec}'`);
     // Supported formats are `lts/<alias>` and `lts/*`. Where asterisk means highest possible LTS.
     const release = alias === '*'
-        ? candidates.find(x => !!x.lts && x.stable === stable)
-        : candidates.find(x => { var _a; return ((_a = x.lts) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === alias && x.stable === stable; });
+        ? manifest.find(x => !!x.lts && x.stable === stable)
+        : manifest.find(x => { var _a; return ((_a = x.lts) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === alias && x.stable === stable; });
     if (!release) {
         throw new Error(`Unable to find LTS release '${alias}' for Node version '${versionSpec}'.`);
     }
@@ -13244,8 +13244,8 @@ function getInfoFromManifest(versionSpec, stable, auth, osArch = translateArchTo
     return __awaiter(this, void 0, void 0, function* () {
         let info = null;
         const releases = yield tc.getManifestFromRepo('actions', 'node-versions', auth, 'main');
-        if (isLtsVersion(versionSpec)) {
-            versionSpec = findLtsVersionFromManifest(versionSpec, stable, releases);
+        if (isLtsAlias(versionSpec)) {
+            versionSpec = resolveLtsAliasFromManifest(versionSpec, stable, releases);
         }
         const rel = yield tc.findFromManifest(versionSpec, stable, releases, osArch);
         if (rel && rel.files.length > 0) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -13111,9 +13111,8 @@ function getNode(versionSpec, stable, checkLatest, auth, arch = os.arch()) {
         let osArch = translateArchToDistUrl(arch);
         if (isLtsAlias(versionSpec)) {
             core.info('Attempt to resolve LTS alias from manifest...');
-            core.debug('Getting manifest from actions/node-versions@main');
             // No try-catch since it's not possible to resolve LTS alias without manifest
-            manifest = yield tc.getManifestFromRepo('actions', 'node-versions', auth, 'main');
+            manifest = yield getManifest(auth);
             versionSpec = resolveLtsAliasFromManifest(versionSpec, stable, manifest);
         }
         if (checkLatest) {
@@ -13228,6 +13227,10 @@ exports.getNode = getNode;
 function isLtsAlias(versionSpec) {
     return versionSpec.startsWith('lts');
 }
+function getManifest(auth) {
+    core.debug('Getting manifest from actions/node-versions@main');
+    return tc.getManifestFromRepo('actions', 'node-versions', auth, 'main');
+}
 function resolveLtsAliasFromManifest(versionSpec, stable, manifest) {
     var _a;
     const alias = (_a = versionSpec.split('lts/')[1]) === null || _a === void 0 ? void 0 : _a.toLowerCase();
@@ -13249,8 +13252,8 @@ function getInfoFromManifest(versionSpec, stable, auth, osArch = translateArchTo
     return __awaiter(this, void 0, void 0, function* () {
         let info = null;
         if (!manifest) {
-            core.debug('No manifest cached, getting manifest from actions/node-versions@main');
-            manifest = yield tc.getManifestFromRepo('actions', 'node-versions', auth, 'main');
+            core.debug('No manifest cached');
+            manifest = yield getManifest(auth);
         }
         const rel = yield tc.findFromManifest(versionSpec, stable, manifest, osArch);
         if (rel && rel.files.length > 0) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -13225,7 +13225,7 @@ function getNode(versionSpec, stable, checkLatest, auth, arch = os.arch()) {
 }
 exports.getNode = getNode;
 function isLtsAlias(versionSpec) {
-    return versionSpec.startsWith('lts');
+    return versionSpec.startsWith('lts/');
 }
 function getManifest(auth) {
     core.debug('Getting manifest from actions/node-versions@main');
@@ -13235,7 +13235,7 @@ function resolveLtsAliasFromManifest(versionSpec, stable, manifest) {
     var _a;
     const alias = (_a = versionSpec.split('lts/')[1]) === null || _a === void 0 ? void 0 : _a.toLowerCase();
     if (!alias) {
-        throw new Error(`Unexpected LTS alias '${alias}' for Node version '${versionSpec}'`);
+        throw new Error(`Unable to parse LTS alias for Node version '${versionSpec}'`);
     }
     core.debug(`LTS alias '${alias}' for Node version '${versionSpec}'`);
     // Supported formats are `lts/<alias>` and `lts/*`. Where asterisk means highest possible LTS.

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -192,6 +192,7 @@ function findLtsVersionFromManifest(
 
   core.debug(`LTS alias '${alias}' for Node version '${versionSpec}'`);
 
+  // Supported formats are `lts/<alias>` and `lts/*`. Where asterisk means highest possible LTS.
   const release = alias === '*'
    ? candidates.find(x => !!x.lts && x.stable === stable)
    : candidates.find(x => x.lts?.toLowerCase() === alias && x.stable === stable);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -42,14 +42,10 @@ export async function getNode(
 
   if (isLtsAlias(versionSpec)) {
     core.info('Attempt to resolve LTS alias from manifest...');
-    core.debug('Getting manifest from actions/node-versions@main');
+
     // No try-catch since it's not possible to resolve LTS alias without manifest
-    manifest = await tc.getManifestFromRepo(
-      'actions',
-      'node-versions',
-      auth,
-      'main'
-    );
+    manifest = await getManifest(auth);
+
     versionSpec = resolveLtsAliasFromManifest(versionSpec, stable, manifest);
   }
 
@@ -200,6 +196,11 @@ function isLtsAlias(versionSpec: string): boolean {
   return versionSpec.startsWith('lts');
 }
 
+function getManifest(auth: string | undefined): Promise<tc.IToolRelease[]> {
+  core.debug('Getting manifest from actions/node-versions@main');
+  return tc.getManifestFromRepo('actions', 'node-versions', auth, 'main');
+}
+
 function resolveLtsAliasFromManifest(
   versionSpec: string,
   stable: boolean,
@@ -245,16 +246,8 @@ async function getInfoFromManifest(
 ): Promise<INodeVersionInfo | null> {
   let info: INodeVersionInfo | null = null;
   if (!manifest) {
-    core.debug(
-      'No manifest cached, getting manifest from actions/node-versions@main'
-    );
-
-    manifest = await tc.getManifestFromRepo(
-      'actions',
-      'node-versions',
-      auth,
-      'main'
-    );
+    core.debug('No manifest cached');
+    manifest = await getManifest(auth);
   }
 
   const rel = await tc.findFromManifest(versionSpec, stable, manifest, osArch);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -192,13 +192,15 @@ function findLtsVersionFromManifest(
 
   core.debug(`LTS alias '${alias}' for Node version '${versionSpec}'`);
 
-  const release = candidates.find(x => x.lts?.toLowerCase() === alias && x.stable === stable);
+  const release = alias === '*'
+   ? candidates.find(x => !!x.lts && x.stable === stable)
+   : candidates.find(x => x.lts?.toLowerCase() === alias && x.stable === stable);
 
   if (!release) {
     throw new Error(`Unable to find LTS release '${alias}' for Node version '${versionSpec}'.`);
   }
 
-  core.debug(`Found LTS release '${alias}' for Node version '${versionSpec}'`);
+  core.debug(`Found LTS release '${release.version}' for Node version '${versionSpec}'`);
 
   return release.version.split('.')[0];
 }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -24,6 +24,10 @@ interface INodeVersionInfo {
   fileName: string;
 }
 
+interface INodeRelease extends tc.IToolRelease {
+  lts?: string;
+}
+
 export async function getNode(
   versionSpec: string,
   stable: boolean,
@@ -182,7 +186,7 @@ function isLts(versionSpec: string): boolean {
 function findLtsVersionFromManifest(
   versionSpec: string,
   stable: boolean,
-  candidates: Array<tc.IToolRelease & { lts?: string }>
+  candidates: INodeRelease[]
 ): string {
   const alias = versionSpec.split('lts/')[1]?.toLowerCase();
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -38,7 +38,7 @@ export async function getNode(
   let osPlat: string = os.platform();
   let osArch: string = translateArchToDistUrl(arch);
 
-  if (isLts(versionSpec)) {
+  if (isLtsVersion(versionSpec)) {
     core.warning('LTS version is provided. For LTS versions `check-latest` will be automatically set to true');
     checkLatest = true;
   }
@@ -179,7 +179,7 @@ export async function getNode(
   core.addPath(toolPath);
 }
 
-function isLts(versionSpec: string): boolean {
+function isLtsVersion(versionSpec: string): boolean {
   return versionSpec.startsWith('lts')
 }
 
@@ -224,7 +224,7 @@ async function getInfoFromManifest(
     'main'
   );
 
-  if (isLts(versionSpec)) {
+  if (isLtsVersion(versionSpec)) {
     versionSpec = findLtsVersionFromManifest(versionSpec, stable, releases);
   }
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -39,7 +39,7 @@ export async function getNode(
   let osArch: string = translateArchToDistUrl(arch);
 
   if (isLtsVersion(versionSpec)) {
-    core.warning('LTS version is provided. For LTS versions `check-latest` will be automatically set to true');
+    core.info('LTS version is provided. For LTS versions `check-latest` will be automatically set to true');
     checkLatest = true;
   }
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -193,7 +193,7 @@ export async function getNode(
 }
 
 function isLtsAlias(versionSpec: string): boolean {
-  return versionSpec.startsWith('lts');
+  return versionSpec.startsWith('lts/');
 }
 
 function getManifest(auth: string | undefined): Promise<tc.IToolRelease[]> {
@@ -210,7 +210,7 @@ function resolveLtsAliasFromManifest(
 
   if (!alias) {
     throw new Error(
-      `Unexpected LTS alias '${alias}' for Node version '${versionSpec}'`
+      `Unable to parse LTS alias for Node version '${versionSpec}'`
     );
   }
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -42,9 +42,14 @@ export async function getNode(
 
   if (isLtsAlias(versionSpec)) {
     core.info('Attempt to resolve LTS alias from manifest...');
-    core.debug('Getting manifest from actions/node-versions@main')
+    core.debug('Getting manifest from actions/node-versions@main');
     // No try-catch since it's not possible to resolve LTS alias without manifest
-    manifest = await tc.getManifestFromRepo('actions', 'node-versions', auth, 'main');
+    manifest = await tc.getManifestFromRepo(
+      'actions',
+      'node-versions',
+      auth,
+      'main'
+    );
     versionSpec = resolveLtsAliasFromManifest(versionSpec, stable, manifest);
   }
 
@@ -81,7 +86,13 @@ export async function getNode(
     // Try download from internal distribution (popular versions only)
     //
     try {
-      info = await getInfoFromManifest(versionSpec, stable, auth, osArch, manifest);
+      info = await getInfoFromManifest(
+        versionSpec,
+        stable,
+        auth,
+        osArch,
+        manifest
+      );
       if (info) {
         core.info(
           `Acquiring ${info.resolvedVersion} - ${info.arch} from ${info.downloadUrl}`
@@ -186,7 +197,7 @@ export async function getNode(
 }
 
 function isLtsAlias(versionSpec: string): boolean {
-  return versionSpec.startsWith('lts')
+  return versionSpec.startsWith('lts');
 }
 
 function resolveLtsAliasFromManifest(
@@ -197,21 +208,30 @@ function resolveLtsAliasFromManifest(
   const alias = versionSpec.split('lts/')[1]?.toLowerCase();
 
   if (!alias) {
-    throw new Error(`Unexpected LTS alias '${alias}' for Node version '${versionSpec}'`);
+    throw new Error(
+      `Unexpected LTS alias '${alias}' for Node version '${versionSpec}'`
+    );
   }
 
   core.debug(`LTS alias '${alias}' for Node version '${versionSpec}'`);
 
   // Supported formats are `lts/<alias>` and `lts/*`. Where asterisk means highest possible LTS.
-  const release = alias === '*'
-   ? manifest.find(x => !!x.lts && x.stable === stable)
-   : manifest.find(x => x.lts?.toLowerCase() === alias && x.stable === stable);
+  const release =
+    alias === '*'
+      ? manifest.find(x => !!x.lts && x.stable === stable)
+      : manifest.find(
+          x => x.lts?.toLowerCase() === alias && x.stable === stable
+        );
 
   if (!release) {
-    throw new Error(`Unable to find LTS release '${alias}' for Node version '${versionSpec}'.`);
+    throw new Error(
+      `Unable to find LTS release '${alias}' for Node version '${versionSpec}'.`
+    );
   }
 
-  core.debug(`Found LTS release '${release.version}' for Node version '${versionSpec}'`);
+  core.debug(
+    `Found LTS release '${release.version}' for Node version '${versionSpec}'`
+  );
 
   return release.version.split('.')[0];
 }
@@ -225,7 +245,9 @@ async function getInfoFromManifest(
 ): Promise<INodeVersionInfo | null> {
   let info: INodeVersionInfo | null = null;
   if (!manifest) {
-    core.debug('No manifest cached, getting manifest from actions/node-versions@main')
+    core.debug(
+      'No manifest cached, getting manifest from actions/node-versions@main'
+    );
 
     manifest = await tc.getManifestFromRepo(
       'actions',
@@ -290,7 +312,13 @@ async function resolveVersionFromManifest(
   manifest: tc.IToolRelease[] | undefined
 ): Promise<string | undefined> {
   try {
-    const info = await getInfoFromManifest(versionSpec, stable, auth, osArch, manifest);
+    const info = await getInfoFromManifest(
+      versionSpec,
+      stable,
+      auth,
+      osArch,
+      manifest
+    );
     return info?.resolvedVersion;
   } catch (err) {
     core.info('Unable to resolve version from manifest...');


### PR DESCRIPTION
The work is related to both https://github.com/actions/setup-node/issues/26 and https://github.com/actions/setup-node/issues/32.

For manifest changes see https://github.com/actions/versions-package-tools/pull/32 and https://github.com/actions/node-versions/pull/63.

- [x] Support `lts/codename` aliases
- [x] Support `lts/*` alias
- [x] Test coverage for `lts/codename` aliases
- [x] Test coverage for `lts/*` alias
- [x] Test coverage for malformed aliases
- [x] Clarify whether I need to commit compiled dist files or not? CC @maxim-lobanov 
- [x] Discuss whether forcing `check-latest = true` is good idea or not? CC @maxim-lobanov 
- [x] Discuss whether it's worth adding support for simple `erbium` or `lts/erbium` is enough? CC @maxim-lobanov @konradpabjan @bryanmacfarlane 

The goal of my PR is to support `.nvmrc` syntax.
**Given**: `.nvmrc`/`.node-version` file in a repository
**When**: run `setup-node` action and pass content of the file to `version` property
**Then**: the action can recognize the format and choose correct node version


Being said that, from my point of view supporting simple `erbium` is not required, since version manager doesn't allow that.
Also, having all codenames starting with `lts/` makes it really easy to determine in the code when `lts` alias passed to the action.

---

Reading the `.nvmrc` file is not the goal of this PR.
A separate PR shall be created for that, but it wouldn't be possible to implement `.nvmrc` reading without supporting the format.
So, think about current PR as a pre-requisite. 🙂 
