### PR TITLE
Automate releasing new action versions

### DIFF
--- a/.github/workflows/release-new-action-version.yml
+++ b/.github/workflows/release-new-action-version.yml
@@ -1,0 +1,27 @@
+name: Release new action version
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      TAG_NAME:
+        description: 'Tag name that the major tag will point to'
+        required: true
+
+env:
+  TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
+permissions:
+  contents: write
+
+jobs:
+  update_tag:
+    name: Update the major tag to include the ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }} changes
+    environment:
+      name: releaseNewActionVersion
+    runs-on: ubuntu-latest
+    steps:
+    - name: Update the ${{ env.TAG_NAME }} tag
+      uses: actions/publish-action@v0.1.0
+      with:
+        source-tag: ${{ env.TAG_NAME }}
+        slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
**Description:**
Currently, releasing new versions of the `setup-node` action is the manual and unreliable process. In scope of this PR we added a workflow file in order to automate creating/updating a major version tag when a new `setup-node` version is released. We use the [actions/publish-action](https://github.com/actions/publish-action) action for this purpose. 

**Details:**
We added:
- the `workflow_dispatch` event to manually trigger a workflow run;
- the `release` webhook event to automatically trigger workflow run when a new action version is released;
- the `releaseNewActionVersion` environment with protection rules to require a manual approval.

Reverting changes is almost the same process as updating major version tag. In case of any issues related to the updated tag, we have to manually trigger workflow run with the previous stable tag as a parameter.