### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,13 +3,13 @@ name: build-test
 on:
   pull_request:
     paths-ignore:
-      - "**.md"
+      - '**.md'
   push:
     branches:
       - main
       - releases/*
     paths-ignore:
-      - "**.md"
+      - '**.md'
 
 jobs:
   build:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,14 +3,14 @@ name: build-test
 on:
   pull_request:
     paths-ignore:
-      - '**.md'    
-  push:    
+      - "**.md"
+  push:
     branches:
       - main
       - releases/*
     paths-ignore:
-      - '**.md'
-      
+      - "**.md"
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 12.x
+          cache: npm
       - run: npm ci
       - run: npm run build
       - run: npm run format-check


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
