### PR TITLE
Fix npm cache compatibility

### DIFF
--- a/src/cache-utils.ts
+++ b/src/cache-utils.ts
@@ -12,7 +12,7 @@ export interface PackageManagerInfo {
 
 export const supportedPackageManagers: SupportedPackageManagers = {
   npm: {
-    lockFilePatterns: ['package-lock.json', 'yarn.lock'],
+    lockFilePatterns: ['package-lock.json', 'npm-shrinkwrap.json'],
     getCacheFolderCommand: 'npm config get cache'
   },
   yarn1: {


### PR DESCRIPTION
## Description

This PR makes the cache property work for all package managers.

## Motivation

The motivation of this pull request is to be able to use ALL package managers while not compromising security - in order to do that we have to restore `npm` functionality and align that usage to the docs. 

The blog post for [npm v7 will include support for yarn.lock files](https://blog.npmjs.org/post/621733939456933888/npm-v7-series-why-keep-package-lockjson)

> One common question we’ve gotten a few times now, once we announce that npm v7 will include support for yarn.lock files, is “Why keep package-lock.json at all, then? Why not just use yarn.lock only?”
> The simple answer is: because yarn.lock doesn’t fully address npm’s needs, and relying on it exclusively would limit our ability to produce optimal package installs or add features in the future.

^ Read to the bottom if you want the full reasoning of the `npm` team/inventor.

## Testing

Have added some POCs based real-life use cases proving it is not reliable to cross-use the `yarn.lock` file between `npm` and `yarn` for node-setup `v2.2.0` and `v2.1.5`:
- https://github.com/0-vortex/node-setup-npm-production-not-compatible-yarn
- https://github.com/0-vortex/node-setup-npm-production-not-compatible-yarn-pre-2.2.0