### PR TITLE
feat(cache): change key to match actions/cache documentation

### DIFF
--- a/__tests__/cache-restore.test.ts
+++ b/__tests__/cache-restore.test.ts
@@ -135,10 +135,10 @@ describe('cache-restore', () => {
         await restoreCache(packageManager);
         expect(hashFilesSpy).toHaveBeenCalled();
         expect(infoSpy).toHaveBeenCalledWith(
-          `Cache restored from key: node-cache-${platform}-${packageManager}-${fileHash}`
+          `Cache restored from key: ${platform}-setup-node-${packageManager}-${fileHash}`
         );
         expect(infoSpy).not.toHaveBeenCalledWith(
-          `${packageManager} cache is not found`
+          `Cache not found for input keys: ${platform}-setup-node-${packageManager}-${fileHash}, ${platform}-setup-node-${packageManager}-, ${platform}-setup-node-`
         );
       }
     );
@@ -165,7 +165,7 @@ describe('cache-restore', () => {
         await restoreCache(packageManager);
         expect(hashFilesSpy).toHaveBeenCalled();
         expect(infoSpy).toHaveBeenCalledWith(
-          `${packageManager} cache is not found`
+          `Cache not found for input keys: ${platform}-setup-node-${packageManager}-${fileHash}, ${platform}-setup-node-${packageManager}-, ${platform}-setup-node-`
         );
       }
     );

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -44663,6 +44663,7 @@ exports.restoreCache = (packageManager, cacheDependencyPath) => __awaiter(void 0
     }
     const platform = process.env.RUNNER_OS;
     const cachePath = yield cache_utils_1.getCacheDirectoryPath(packageManagerInfo, packageManager);
+    const paths = [cachePath];
     const lockFilePath = cacheDependencyPath
         ? cacheDependencyPath
         : findLockFile(packageManagerInfo);
@@ -44670,12 +44671,14 @@ exports.restoreCache = (packageManager, cacheDependencyPath) => __awaiter(void 0
     if (!fileHash) {
         throw new Error('Some specified paths were not resolved, unable to cache dependencies.');
     }
-    const primaryKey = `node-cache-${platform}-${packageManager}-${fileHash}`;
+    const keyPrefix = `${platform}-setup-node-`;
+    const primaryKey = `${keyPrefix}${packageManager}-${fileHash}`;
+    const restoreKeys = [`${keyPrefix}${packageManager}-`, keyPrefix];
     core.debug(`primary key is ${primaryKey}`);
     core.saveState(constants_1.State.CachePrimaryKey, primaryKey);
-    const cacheKey = yield cache.restoreCache([cachePath], primaryKey);
+    const cacheKey = yield cache.restoreCache(paths, primaryKey, restoreKeys);
     if (!cacheKey) {
-        core.info(`${packageManager} cache is not found`);
+        core.info(`Cache not found for input keys: ${[primaryKey, ...restoreKeys].join(', ')}`);
         return;
     }
     core.saveState(constants_1.State.CacheMatchedKey, cacheKey);


### PR DESCRIPTION
This PR change the cache key construction to fit [those examples](https://github.com/actions/cache/blob/main/examples.md#node---npm). It also add the use of restoreKeys and a more verbose log when retrieving fails.