### PR TITLE
Add support for node 16.13 Gallium LTS

### DIFF
--- a/__tests__/data/versions-manifest.json
+++ b/__tests__/data/versions-manifest.json
@@ -1,5 +1,31 @@
 [
     {
+      "version": "16.13.0",
+      "stable": true,
+      "lts": "Gallium",
+      "release_url": "https://github.com/actions/node-versions/releases/tag/16.13.0-1386584131",
+      "files": [
+        {
+          "filename": "node-16.13.0-darwin-x64.tar.gz",
+          "arch": "x64",
+          "platform": "darwin",
+          "download_url": "https://github.com/actions/node-versions/releases/download/16.13.0-1386584131/node-16.13.0-darwin-x64.tar.gz"
+        },
+        {
+          "filename": "node-16.13.0-linux-x64.tar.gz",
+          "arch": "x64",
+          "platform": "linux",
+          "download_url": "https://github.com/actions/node-versions/releases/download/16.13.0-1386584131/node-16.13.0-linux-x64.tar.gz"
+        },
+        {
+          "filename": "node-16.13.0-win32-x64.7z",
+          "arch": "x64",
+          "platform": "win32",
+          "download_url": "https://github.com/actions/node-versions/releases/download/16.13.0-1386584131/node-16.13.0-win32-x64.7z"
+        }
+      ]
+    },
+    {
       "version": "14.0.0",
       "stable": true,
       "lts": "Fermium",


### PR DESCRIPTION
**Description:**
I believe this adds support for LTS Gallium. Please correct me if I've done this incorrectly.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.