### PR TITLE
docs: recommend npm ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ steps:
 - uses: actions/setup-node@v2
   with:
     node-version: '14'
-- run: npm install
+- run: npm ci
 - run: npm test
 ```
 
@@ -55,7 +55,7 @@ steps:
   with:
     node-version: '14'
     cache: 'npm'
-- run: npm install
+- run: npm ci
 - run: npm test
 ```
 
@@ -68,7 +68,7 @@ steps:
     node-version: '14'
     cache: 'npm'
     cache-dependency-path: subdir/package-lock.json
-- run: npm install
+- run: npm ci
 - run: npm test
 ```
 
@@ -87,7 +87,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
-      - run: npm install
+      - run: npm ci
       - run: npm test
 ```
 ## Advanced usage


### PR DESCRIPTION
**Description:**
Docs to use `npm ci` instead of `npm install`.

According to [npm docs](https://docs.npmjs.com/cli/v8/commands/npm-ci):
> **npm ci**
> This command is similar to npm install, except it's meant to be used in automated environments such as test platforms, continuous integration, and deployment -- or any situation where you want to make sure you're doing a clean install of your dependencies.
>
> npm ci will be significantly faster when:
> - There is a package-lock.json or npm-shrinkwrap.json file.
> - The node_modules folder is missing or empty.

In particular, the benefit of using `npm ci` over `npm install` is that there will not by any dependency discrepancy because it installs the exact dependency versions from lock. In contrast, `npm install` will install any new version that fits into the semver range defined in `package.json`, which can yield to unexpected behavior or bugs.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.