### PR TITLE
Updated documentation/workflows to use `actions/setup-node@v3`

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,8 +19,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
-      - name: Setup node 16
-        uses: actions/setup-node@v2
+      - name: Setup Node 16.x
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
           cache: npm

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -23,8 +23,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set Node.js 16.x
-        uses: actions/setup-node@v2
+      - name: Setup Node 16.x
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
           cache: npm

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ See [action.yml](action.yml)
 ```yaml
 steps:
 - uses: actions/checkout@v2
-- uses: actions/setup-node@v2
+- uses: actions/setup-node@v3
   with:
     node-version: '14'
 - run: npm install
 - run: npm test
 ```
 
-The `node-version` input is optional. If not supplied, the node version from PATH will be used. However, it is recommended to always specify Node.js version and don't rely on the system one.  
+The `node-version` input is optional. If not supplied, the node version from PATH will be used. However, it is recommended to always specify Node.js version and don't rely on the system one.
 
 The action will first check the local cache for a semver match. If unable to find a specific version in the cache, the action will attempt to download a version of Node.js. It will pull LTS versions from [node-versions releases](https://github.com/actions/node-versions/releases) and on miss or failure will fall back to the previous behavior of downloading directly from [node dist](https://nodejs.org/dist/).
 
@@ -35,9 +35,9 @@ For information regarding locally cached versions of Node.js on GitHub hosted ru
 #### Supported version syntax
 The `node-version` input supports the following syntax:
 
-major versions: `12`, `14`, `16`  
-more specific versions: `10.15`, `14.2.0`, `16.3.0`  
-nvm lts syntax: `lts/erbium`, `lts/fermium`, `lts/*`  
+major versions: `12`, `14`, `16`
+more specific versions: `10.15`, `14.2.0`, `16.3.0`
+nvm lts syntax: `lts/erbium`, `lts/fermium`, `lts/*`
 
 ## Caching packages dependencies
 
@@ -51,7 +51,7 @@ See the examples of using cache for `yarn` / `pnpm` and  `cache-dependency-path`
 ```yaml
 steps:
 - uses: actions/checkout@v2
-- uses: actions/setup-node@v2
+- uses: actions/setup-node@v3
   with:
     node-version: '14'
     cache: 'npm'
@@ -63,7 +63,7 @@ steps:
 ```yaml
 steps:
 - uses: actions/checkout@v2
-- uses: actions/setup-node@v2
+- uses: actions/setup-node@v3
   with:
     node-version: '14'
     cache: 'npm'
@@ -84,7 +84,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - run: npm install

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # setup-node
 
-<p align="left">
-  <a href="https://github.com/actions/setup-node/actions?query=workflow%3Abuild-test"><img alt="build-test status" src="https://github.com/actions/setup-node/workflows/build-test/badge.svg"></a> <a href="https://github.com/actions/setup-node/actions?query=workflow%3Aversions"><img alt="versions status" src="https://github.com/actions/setup-node/workflows/versions/badge.svg"></a> <a href="https://github.com/actions/setup-node/actions?query=workflow%3Aproxy"><img alt="proxy status" src="https://github.com/actions/setup-node/workflows/proxy/badge.svg"></a> 
-</p>
+[![build-test](https://github.com/actions/setup-node/actions/workflows/build-test.yml/badge.svg)](https://github.com/actions/setup-node/actions/workflows/build-test.yml)
+[![versions](https://github.com/actions/setup-node/actions/workflows/versions.yml/badge.svg)](https://github.com/actions/setup-node/actions/workflows/versions.yml)
+[![proxy](https://github.com/actions/setup-node/actions/workflows/proxy.yml/badge.svg)](https://github.com/actions/setup-node/actions/workflows/proxy.yml)
 
 This action provides the following functionality for GitHub Actions users:
 
@@ -33,6 +33,7 @@ The action will first check the local cache for a semver match. If unable to fin
 For information regarding locally cached versions of Node.js on GitHub hosted runners, check out [GitHub Actions Virtual Environments](https://github.com/actions/virtual-environments).
 
 #### Supported version syntax
+
 The `node-version` input supports the following syntax:
 
 major versions: `12`, `14`, `16`
@@ -73,6 +74,7 @@ steps:
 ```
 
 ## Matrix Testing:
+
 ```yaml
 jobs:
   build:

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -11,7 +11,7 @@ If `check-latest` is set to `true`, the action first checks if the cached versio
 ```yaml
 steps:
 - uses: actions/checkout@v2
-- uses: actions/setup-node@v2
+- uses: actions/setup-node@v3
   with:
     node-version: '14'
     check-latest: true
@@ -20,15 +20,15 @@ steps:
 ```
 
 ## Node version file
-  
-The `node-version-file` input accepts a path to a file containing the version of Node.js to be used by a project, for example `.nvmrc` or `.node-version`. If both the `node-version` and the `node-version-file` inputs are provided then the `node-version` input is used. 
-See [supported version syntax](https://github.com/actions/setup-node#supported-version-syntax) 
+
+The `node-version-file` input accepts a path to a file containing the version of Node.js to be used by a project, for example `.nvmrc` or `.node-version`. If both the `node-version` and the `node-version-file` inputs are provided then the `node-version` input is used.
+See [supported version syntax](https://github.com/actions/setup-node#supported-version-syntax)
 > The action will search for the node version file relative to the repository root.
 
 ```yaml
 steps:
 - uses: actions/checkout@v2
-- uses: actions/setup-node@v2
+- uses: actions/setup-node@v3
   with:
     node-version-file: '.nvmrc'
 - run: npm install
@@ -47,7 +47,7 @@ jobs:
     name: Node sample
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
           architecture: 'x64' # optional, x64 or x86. If not specified, x64 will be used by default
@@ -58,12 +58,12 @@ jobs:
 ## Caching packages dependencies
 The action follows [actions/cache](https://github.com/actions/cache/blob/main/examples.md#node---npm) guidelines, and caches global cache on the machine instead of `node_modules`, so cache can be reused between different Node.js versions.
 
-**Caching yarn dependencies:**  
+**Caching yarn dependencies:**
 Yarn caching handles both yarn versions: 1 or 2.
 ```yaml
 steps:
 - uses: actions/checkout@v2
-- uses: actions/setup-node@v2
+- uses: actions/setup-node@v3
   with:
     node-version: '14'
     cache: 'yarn'
@@ -85,7 +85,7 @@ steps:
 - uses: pnpm/action-setup@646cdf48217256a3d0b80361c5a50727664284f2
   with:
     version: 6.10.0
-- uses: actions/setup-node@v2
+- uses: actions/setup-node@v3
   with:
     node-version: '14'
     cache: 'pnpm'
@@ -97,7 +97,7 @@ steps:
 ```yaml
 steps:
 - uses: actions/checkout@v2
-- uses: actions/setup-node@v2
+- uses: actions/setup-node@v3
   with:
     node-version: '14'
     cache: 'npm'
@@ -110,7 +110,7 @@ steps:
 ```yaml
 steps:
 - uses: actions/checkout@v2
-- uses: actions/setup-node@v2
+- uses: actions/setup-node@v3
   with:
     node-version: '14'
     cache: 'npm'
@@ -148,7 +148,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}
           architecture: ${{ matrix.architecture }}
@@ -160,7 +160,7 @@ jobs:
 ```yaml
 steps:
 - uses: actions/checkout@v2
-- uses: actions/setup-node@v2
+- uses: actions/setup-node@v3
   with:
     node-version: '14.x'
     registry-url: 'https://registry.npmjs.org'
@@ -168,7 +168,7 @@ steps:
 - run: npm publish
   env:
     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-- uses: actions/setup-node@v2
+- uses: actions/setup-node@v3
   with:
     registry-url: 'https://npm.pkg.github.com'
 - run: npm publish
@@ -180,7 +180,7 @@ steps:
 ```yaml
 steps:
 - uses: actions/checkout@v2
-- uses: actions/setup-node@v2
+- uses: actions/setup-node@v3
   with:
     node-version: '14.x'
     registry-url: <registry url>
@@ -188,7 +188,7 @@ steps:
 - run: yarn publish
   env:
     NODE_AUTH_TOKEN: ${{ secrets.YARN_TOKEN }}
-- uses: actions/setup-node@v2
+- uses: actions/setup-node@v3
   with:
     registry-url: 'https://npm.pkg.github.com'
 - run: yarn publish
@@ -200,7 +200,7 @@ steps:
 ```yaml
 steps:
 - uses: actions/checkout@v2
-- uses: actions/setup-node@v2
+- uses: actions/setup-node@v3
   with:
     node-version: '14.x'
     registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
**Description:**

- Congrats on the `@v3` release - noted that some documentation hasn't been updated to suit.
- Left the ADRs as is - figured they should be "frozen in time" of authoring.
- Also updated internal GitHub workflows that use itself to `@v3`.
- Also fixed the `README.md` build badges to the new format generated by the GitHub Actions UI (Create status badge).

**Related issue:**
N/A

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.