### PR TITLE
Bump to `actions/checkout@v3`

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Node 16.x
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -45,7 +45,7 @@ jobs:
         id: diff
 
       # If index.js was different than expected, upload the expected version as an artifact
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Node 16.x
         uses: actions/setup-node@v3

--- a/.github/workflows/e2e-cache.yml
+++ b/.github/workflows/e2e-cache.yml
@@ -10,7 +10,7 @@ on:
       - releases/*
     paths-ignore:
       - '**.md'
-      
+
 jobs:
   node-npm-depencies-caching:
     name: Test npm (Node ${{ matrix.node-version}}, ${{ matrix.os }})
@@ -21,7 +21,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [12, 14, 16]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Clean global cache
         run: npm cache clean --force
       - name: Setup Node
@@ -44,7 +44,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [12, 14, 16]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
@@ -77,7 +77,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [12, 14, 16]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Yarn version
         run: yarn --version
       - name: Generate yarn file
@@ -109,7 +109,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [12, 14, 16]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Update yarn
         run: yarn set version berry
       - name: Yarn version

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check licenses
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: npm ci
       - name: Install licensed
         run: |

--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -25,7 +25,7 @@ jobs:
     env:
       https_proxy: http://squid-proxy:3128
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Clear tool cache
         run: rm -rf $RUNNER_TOOL_CACHE/*
       - name: Setup node 14
@@ -41,7 +41,7 @@ jobs:
       https_proxy: http://no-such-proxy:3128
       no_proxy: api.github.com,github.com,nodejs.org,registry.npmjs.org,*.s3.amazonaws.com,s3.amazonaws.com
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Clear tool cache
         run: rm -rf $RUNNER_TOOL_CACHE/*
       - name: Setup node 11

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -3,14 +3,14 @@ name: versions
 on:
   pull_request:
     paths-ignore:
-      - '**.md'    
-  push:    
+      - '**.md'
+  push:
     branches:
       - main
       - releases/*
     paths-ignore:
       - '**.md'
-      
+
 jobs:
   local-cache:
     runs-on: ${{ matrix.os }}
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [10, 12, 14]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Node
         uses: ./
         with:
@@ -37,7 +37,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [lts/dubnium, lts/erbium, lts/fermium, lts/*]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Node
         uses: ./
         with:
@@ -51,7 +51,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [10.15, 12.16.0, 14.2.0, 16.3.0]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Node
         uses: ./
         with:
@@ -68,7 +68,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [10, 12, 14]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Node and check latest
         uses: ./
         with:
@@ -85,7 +85,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup node from node version file
         uses: ./
         with:
@@ -101,7 +101,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [11, 13]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Node from dist
         uses: ./
         with:
@@ -117,7 +117,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # test old versions which didn't have npm and layout different
       - name: Setup node 0.12.18 from dist
         uses: ./
@@ -130,7 +130,7 @@ jobs:
   arch:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup node 14 x86 from dist
         uses: ./
         with:

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ This action provides the following functionality for GitHub Actions users:
 See [action.yml](action.yml)
 
 **Basic:**
+
 ```yaml
 steps:
-- uses: actions/checkout@v2
+- uses: actions/checkout@v3
 - uses: actions/setup-node@v3
   with:
     node-version: '14'
@@ -49,9 +50,10 @@ The action defaults to search for the dependency file (`package-lock.json` or `y
 See the examples of using cache for `yarn` / `pnpm` and  `cache-dependency-path` input in the [Advanced usage](docs/advanced-usage.md#caching-packages-dependencies) guide.
 
 **Caching npm dependencies:**
+
 ```yaml
 steps:
-- uses: actions/checkout@v2
+- uses: actions/checkout@v3
 - uses: actions/setup-node@v3
   with:
     node-version: '14'
@@ -61,9 +63,10 @@ steps:
 ```
 
 **Caching npm dependencies in monorepos:**
+
 ```yaml
 steps:
-- uses: actions/checkout@v2
+- uses: actions/checkout@v3
 - uses: actions/setup-node@v3
   with:
     node-version: '14'
@@ -84,7 +87,7 @@ jobs:
         node: [ '12', '14', '16' ]
     name: Node ${{ matrix.node }} sample
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup node
         uses: actions/setup-node@v3
         with:
@@ -92,6 +95,7 @@ jobs:
       - run: npm install
       - run: npm test
 ```
+
 ## Advanced usage
 
 1. [Check latest version](docs/advanced-usage.md#check-latest-version)


### PR DESCRIPTION
**Description:**

- Bump `actions/checkout` to `@v3`
- Also noted (and bumped) `actions/upload-artifact` to `@v3` (released after I cut this PR).

https://github.com/actions/checkout/releases/tag/v3.0.0

**Related issue:**
N/A

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.