### PR TITLE
Support npm-shrinkwrap.json out-of-the-box

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ It's **always** recommended to commit the lockfile of your package manager for s
 
 The action has a built-in functionality for caching and restoring dependencies. It uses [actions/cache](https://github.com/actions/cache) under the hood for caching global packages data but requires less configuration settings. Supported package managers are `npm`, `yarn`, `pnpm` (v6.10+). The `cache` input is optional, and caching is turned off by default.
 
-The action defaults to search for the dependency file (`package-lock.json` or `yarn.lock`) in the repository root, and uses its hash as a part of the cache key. Use `cache-dependency-path` for cases when multiple dependency files are used, or they are located in different subdirectories.
+The action defaults to search for the dependency file (`package-lock.json`, `npm-shrinkwrap.json` or `yarn.lock`) in the repository root, and uses its hash as a part of the cache key. Use `cache-dependency-path` for cases when multiple dependency files are used, or they are located in different subdirectories.
 
 **Note:** The action does not cache `node_modules`
 

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -59926,7 +59926,7 @@ const exec = __importStar(__nccwpck_require__(1514));
 const cache = __importStar(__nccwpck_require__(7799));
 exports.supportedPackageManagers = {
     npm: {
-        lockFilePatterns: ['package-lock.json', 'yarn.lock'],
+        lockFilePatterns: ['package-lock.json', 'npm-shrinkwrap.json', 'yarn.lock'],
         getCacheFolderCommand: 'npm config get cache'
     },
     pnpm: {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -71272,7 +71272,7 @@ const exec = __importStar(__nccwpck_require__(1514));
 const cache = __importStar(__nccwpck_require__(7799));
 exports.supportedPackageManagers = {
     npm: {
-        lockFilePatterns: ['package-lock.json', 'yarn.lock'],
+        lockFilePatterns: ['package-lock.json', 'npm-shrinkwrap.json', 'yarn.lock'],
         getCacheFolderCommand: 'npm config get cache'
     },
     pnpm: {

--- a/src/cache-utils.ts
+++ b/src/cache-utils.ts
@@ -13,7 +13,7 @@ export interface PackageManagerInfo {
 
 export const supportedPackageManagers: SupportedPackageManagers = {
   npm: {
-    lockFilePatterns: ['package-lock.json', 'yarn.lock'],
+    lockFilePatterns: ['package-lock.json', 'npm-shrinkwrap.json', 'yarn.lock'],
     getCacheFolderCommand: 'npm config get cache'
   },
   pnpm: {


### PR DESCRIPTION
**Description:**

`npm-shrinkwrap.json` is now supported as an npm lock file. This file has the exact same contents as `package-lock.json`, it just has slightly different semantics at publish time. This is important because application projects (as opposed to libraries) _should_ use `npm-shrinkwrap.json`: https://docs.npmjs.com/cli/v8/configuring-npm/package-lock-json#package-lockjson-vs-npm-shrinkwrapjson

I'm not sure if there are tests that need to be updated here. I grepped for `package-lock` and the only result I found was a mock, so it seems like this list of files isn't actually tested anywhere...? Happy to amend if needed.

**Related issue:**

#302 was the original request. A workaround is now possible, but this PR makes this work out-of-the-box with no workarounds required.

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.