### PR TITLE
Add ability to use package json version.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -72,6 +72,18 @@ function resolveVersionInput(): string {
       'Both node-version and node-version-file inputs are specified, only node-version will be used'
     );
   }
+  
+  if (version === "package") {
+    const packageJson = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          process.env.GITHUB_WORKSPACE!, 
+          "package.json"
+        )
+      )
+    );
+    return packageJson.engines.node;
+  }
 
   if (version) {
     return version;


### PR DESCRIPTION
This will only work with top level package json file and not nested files.

**Description:**
Adds the ability to specify "package" as node version instead of a number

**Related issue:**
#467 

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.