### PR TITLE
extend documentation on `scope` parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,35 +1,35 @@
 name: 'Setup Node.js environment'
-description: 'Setup a Node.js environment by adding problem matchers and optionally downloading and adding it to the PATH'
+description: 'Setup a Node.js environment by adding problem matchers and optionally downloading and adding it to the PATH.'
 author: 'GitHub'
 inputs:
   always-auth:
-    description: 'Set always-auth in npmrc'
+    description: 'Set always-auth in npmrc.'
     default: 'false'
   node-version:
-    description: 'Version Spec of the version to use.  Examples: 12.x, 10.15.1, >=10.15.0'
+    description: 'Version Spec of the version to use. Examples: 12.x, 10.15.1, >=10.15.0.'
   node-version-file:
-    description: 'File containing the version Spec of the version to use.  Examples: .nvmrc, .node-version'
+    description: 'File containing the version Spec of the version to use.  Examples: .nvmrc, .node-version.'
   architecture:
     description: 'Target architecture for Node to use. Examples: x86, x64. Will use system architecture by default.'
   check-latest:
-    description: 'Set this option if you want the action to check for the latest available version that satisfies the version spec'
+    description: 'Set this option if you want the action to check for the latest available version that satisfies the version spec.'
     default: false
   registry-url:
-    description: 'Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN'
+    description: 'Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN.'
   scope:
-    description: 'Optional scope for authenticating against scoped registries'
+    description: 'Optional scope for authenticating against scoped registries. Will fall back to the repository owner when using the GitHub Packages registry (https://npm.pkg.github.com/).'
   token:
     description: Used to pull node distributions from node-versions.  Since there's a default, this is typically not supplied by the user.
     default: ${{ github.token }}
   cache:
-    description: 'Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm'
+    description: 'Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm.'
   cache-dependency-path:
     description: 'Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc. Supports wildcards or a list of file names for caching multiple dependencies.'
 # TODO: add input to control forcing to pull from cloud or dist. 
 #       escape valve for someone having issues or needing the absolute latest which isn't cached yet
 outputs:
   cache-hit: 
-    description: 'A boolean value to indicate if a cache was hit'
+    description: 'A boolean value to indicate if a cache was hit.'
 runs:
   using: 'node16'
   main: 'dist/setup/index.js'


### PR DESCRIPTION
**Description:**
In [`writeRegistryToFile()`](https://github.com/actions/setup-node/blob/6e4a7921f09320d9891f6ccda63804def2ff9da2/lib/authutil.js#L23-L52) (added in https://github.com/actions/setup-node/pull/21/files#diff-a3c83546a6fde2740e1dd05c8267c74af1c8a7fe3add285eea3669b3760ac6f3R25-R27), `scope` falls back to the repository owner if the `npm.pkg.github.com` registry (GitHub Packages) is used.
Since in most cases, this means that the `scope` parameter is not needed, but the logic is not documented anywhere, this PR adds the appropriate note to the parameter description.

**Related issue:**
None.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.