### PR TITLE
Add test for node-version *

### DIFF
--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -127,6 +127,24 @@ jobs:
         run: __tests__/verify-node.sh 0.12.18 SKIP_NPM
         shell: bash
 
+  latest-version:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: ./
+        with:
+          node-version: '*'
+          check-latest: true
+      - name: Verify node and npm
+        run: |
+          . "$NVM_DIR/nvm.sh"
+          [[ $(nvm version-remote node) =~ ^v([^.]+) ]]
+          __tests__/verify-node.sh "${BASH_REMATCH[1]}"
+        shell: bash
+
   arch:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -127,24 +127,6 @@ jobs:
         run: __tests__/verify-node.sh 0.12.18 SKIP_NPM
         shell: bash
 
-  latest-version:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup Node
-        uses: ./
-        with:
-          node-version: '*'
-          check-latest: true
-      - name: Verify node and npm
-        run: |
-          . "$NVM_DIR/nvm.sh"
-          [[ $(nvm version-remote node) =~ ^v([^.]+) ]]
-          __tests__/verify-node.sh "${BASH_REMATCH[1]}"
-        shell: bash
-
   arch:
     runs-on: windows-latest
     steps:

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -135,50 +135,28 @@ describe('setup-node', () => {
     expect(versions?.length).toBe(23);
   });
 
-  it('can find 12.16.2 from manifest on osx', async () => {
-    os.platform = 'darwin';
-    os.arch = 'x64';
-    let versions: tc.IToolRelease[] | null = await tc.getManifestFromRepo(
-      'actions',
-      'node-versions',
-      'mocktoken'
-    );
-    expect(versions).toBeDefined();
-    let match = await tc.findFromManifest('12.16.2', true, versions);
-    expect(match).toBeDefined();
-    expect(match?.version).toBe('12.16.2');
-    expect((match as any).lts).toBe('Erbium');
-  });
-
-  it('can find 12 from manifest on linux', async () => {
-    os.platform = 'linux';
-    os.arch = 'x64';
-    let versions: tc.IToolRelease[] | null = await tc.getManifestFromRepo(
-      'actions',
-      'node-versions',
-      'mocktoken'
-    );
-    expect(versions).toBeDefined();
-    let match = await tc.findFromManifest('12.16.2', true, versions);
-    expect(match).toBeDefined();
-    expect(match?.version).toBe('12.16.2');
-    expect((match as any).lts).toBe('Erbium');
-  });
-
-  it('can find 10 from manifest on windows', async () => {
-    os.platform = 'win32';
-    os.arch = 'x64';
-    let versions: tc.IToolRelease[] | null = await tc.getManifestFromRepo(
-      'actions',
-      'node-versions',
-      'mocktoken'
-    );
-    expect(versions).toBeDefined();
-    let match = await tc.findFromManifest('10', true, versions);
-    expect(match).toBeDefined();
-    expect(match?.version).toBe('10.20.1');
-    expect((match as any).lts).toBe('Dubnium');
-  });
+  it.each([
+    ['12.16.2', 'darwin', '12.16.2', 'Erbium'],
+    ['12', 'linux', '12.16.2', 'Erbium'],
+    ['10', 'win32', '10.20.1', 'Dubnium'],
+    ['*', 'linux', '14.0.0', 'Fermium']
+  ])(
+    'can find %s from manifest on %s',
+    async (versionSpec, platform, expectedVersion, expectedLts) => {
+      os.platform = platform;
+      os.arch = 'x64';
+      let versions: tc.IToolRelease[] | null = await tc.getManifestFromRepo(
+        'actions',
+        'node-versions',
+        'mocktoken'
+      );
+      expect(versions).toBeDefined();
+      let match = await tc.findFromManifest(versionSpec, true, versions);
+      expect(match).toBeDefined();
+      expect(match?.version).toBe(expectedVersion);
+      expect((match as any).lts).toBe(expectedLts);
+    }
+  );
 
   //--------------------------------------------------
   // Found in cache tests


### PR DESCRIPTION
**Description:**
This PR only adds test coverage for existing behavior: It adds a unit and e2e test for node-version `*`.

What I did was:
- Combine the following three tests with `it.each(table)` --- but I'm happy to leave them unrolled if you prefer?
  - https://github.com/actions/setup-node/blob/17f8bd926464a1afa4c6a11669539e9c1ba77048/__tests__/installer.test.ts#L138
  - https://github.com/actions/setup-node/blob/17f8bd926464a1afa4c6a11669539e9c1ba77048/__tests__/installer.test.ts#L153
  - https://github.com/actions/setup-node/blob/17f8bd926464a1afa4c6a11669539e9c1ba77048/__tests__/installer.test.ts#L168
- Added a new row for testing `*`:
  ```ts
  it.each([
    ['12.16.2', 'darwin', '12.16.2', 'Erbium'],
    ['12', 'linux', '12.16.2', 'Erbium'],
    ['10', 'win32', '10.20.1', 'Dubnium'],
    ['*', 'linux', '14.0.0', 'Fermium'] // <- Added a new row
  ])(
    'can find %s from manifest on %s',
    async (versionSpec, platform, expectedVersion, expectedLts) => {
  ```
- Added an e2e test for node-version `*`.

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.