### PR TITLE
Fix: Show warning instead of failing the run

### DIFF
--- a/__tests__/cache-utils.test.ts
+++ b/__tests__/cache-utils.test.ts
@@ -46,7 +46,8 @@ describe('cache-utils', () => {
     isFeatureAvailable.mockImplementation(() => false);
     process.env['GITHUB_SERVER_URL'] = 'https://www.test.com';
 
-    expect(() => isCacheFeatureAvailable()).toThrowError(
+    isCacheFeatureAvailable();
+    expect(warningSpy).toHaveBeenCalledWith(
       'Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.'
     );
   });

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -644,8 +644,8 @@ describe('setup-node', () => {
 
       await main.run();
 
-      expect(cnSpy).toHaveBeenCalledWith(
-        `::error::Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.${osm.EOL}`
+      expect(warningSpy).toHaveBeenCalledWith(
+        'Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.'
       );
     });
 

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -59209,7 +59209,7 @@ exports.isGhes = isGhes;
 function isCacheFeatureAvailable() {
     if (!cache.isFeatureAvailable()) {
         if (isGhes()) {
-            throw new Error('Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.');
+            core.warning('Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.');
         }
         else {
             core.warning('The runner was not able to contact the cache service. Caching will be skipped');

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -70545,7 +70545,7 @@ exports.isGhes = isGhes;
 function isCacheFeatureAvailable() {
     if (!cache.isFeatureAvailable()) {
         if (isGhes()) {
-            throw new Error('Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.');
+            core.warning('Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.');
         }
         else {
             core.warning('The runner was not able to contact the cache service. Caching will be skipped');
@@ -71027,7 +71027,6 @@ function run() {
             //
             let version = resolveVersionInput();
             let arch = core.getInput('architecture');
-            const cache = core.getInput('cache');
             // if architecture supplied but node-version is not
             // if we don't throw a warning, the already installed x64 node will be used which is not probably what user meant.
             if (arch && !version) {
@@ -71043,6 +71042,12 @@ function run() {
                 const checkLatest = (core.getInput('check-latest') || 'false').toUpperCase() === 'TRUE';
                 yield installer.getNode(version, stable, checkLatest, auth, arch);
             }
+        }
+        catch (err) {
+            core.setFailed(err.message);
+        }
+        try {
+            const cache = core.getInput('cache');
             const registryUrl = core.getInput('registry-url');
             const alwaysAuth = core.getInput('always-auth');
             if (registryUrl) {
@@ -71058,7 +71063,7 @@ function run() {
             core.info(`##[add-matcher]${path.join(matchersPath, 'eslint-compact.json')}`);
         }
         catch (err) {
-            core.setFailed(err.message);
+            core.warning(err.message);
         }
     });
 }

--- a/src/cache-utils.ts
+++ b/src/cache-utils.ts
@@ -107,7 +107,7 @@ export function isGhes(): boolean {
 export function isCacheFeatureAvailable(): boolean {
   if (!cache.isFeatureAvailable()) {
     if (isGhes()) {
-      throw new Error(
+      core.warning(
         'Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.'
       );
     } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,6 @@ export async function run() {
     let version = resolveVersionInput();
 
     let arch = core.getInput('architecture');
-    const cache = core.getInput('cache');
 
     // if architecture supplied but node-version is not
     // if we don't throw a warning, the already installed x64 node will be used which is not probably what user meant.
@@ -39,6 +38,13 @@ export async function run() {
       await installer.getNode(version, stable, checkLatest, auth, arch);
     }
 
+  } catch (err) {
+    core.setFailed(err.message);
+  }
+
+  try {
+    const cache = core.getInput('cache');
+
     const registryUrl: string = core.getInput('registry-url');
     const alwaysAuth: string = core.getInput('always-auth');
     if (registryUrl) {
@@ -59,7 +65,7 @@ export async function run() {
       `##[add-matcher]${path.join(matchersPath, 'eslint-compact.json')}`
     );
   } catch (err) {
-    core.setFailed(err.message);
+    core.warning(err.message);
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,7 +37,6 @@ export async function run() {
         (core.getInput('check-latest') || 'false').toUpperCase() === 'TRUE';
       await installer.getNode(version, stable, checkLatest, auth, arch);
     }
-
   } catch (err) {
     core.setFailed(err.message);
   }


### PR DESCRIPTION
**Description:**
As there are currently issues with the caching service which is breaking workflows using the caching I suggest we change the workflow to only *fail* when there are configuration errors. When anything else goes wrong in the workflow, like a 503 error there should be a warning but let the workflow run continue. 

Having caching available or not should not be breaking the workflow, instead, just continue as if there is no cache. 

**Related issue:**
https://github.com/actions/setup-node/issues/516


**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.