### PR TITLE
docs(readme): update supported major versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For information regarding locally cached versions of Node.js on GitHub hosted ru
 
 The `node-version` input supports the following values:
 
- - Major versions: `12`, `14`, `16`
+ - Major versions: `14`, `16`, `18`
  - More specific versions: `10.15`, `14.2.0`, `16.3.0`
  - NVM LTS syntax: `lts/erbium`, `lts/fermium`, `lts/*`, `lts/-n`
  - Latest release: `*` or `latest`/`current`/`node`


### PR DESCRIPTION
**Description:**

* Update README to explicitly show support for Node 18 (confirmed from trying it)
* Remove Node 12 from list, as it has been EOL'ed

Should https://github.com/actions/setup-node/blob/main/.github/workflows/versions.yml be updated as well? I didn't see Node 16 in all the jobs, so I wasn't sure if that workflow is meant to match the readme.

Would it be worth wording the README in a way that indicates support for every major version? Or do we want to check each time a new major version is released?

**Related issue:**

N/A

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.