### PR TITLE
Document ways to get resolved versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ jobs:
 6. [Publishing to npmjs and GPR with npm](docs/advanced-usage.md#publish-to-npmjs-and-gpr-with-npm)
 7. [Publishing to npmjs and GPR with yarn](docs/advanced-usage.md#publish-to-npmjs-and-gpr-with-yarn)
 8. [Using private packages](docs/advanced-usage.md#use-private-packages)
+9. [Resolved Node.js and npm versions](docs/advanced-usage.md#resolved-nodejs-and-npm-versions)
 
 ## License
 

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -247,3 +247,28 @@ steps:
 # `npm rebuild` will run all those post-install scripts for us.
 - run: npm rebuild && npm run prepare --if-present
 ```
+
+## Resolved Node.js and npm versions
+
+In the context of a command, you can get the resolved Node.js and npm versions directly by using command substitution, e.g.:
+
+```yaml
+- if: always()
+  name: Add summary
+  run: |
+    echo "## Versions
+
+    | Node.js           | npm              |
+    | ----------------- | ---------------- |
+    | $(node --version) | $(npm --version) |" > "$GITHUB_STEP_SUMMARY"
+```
+
+If instead you need them in the context of an [expression](https://docs.github.com/en/actions/learn-github-actions/expressions), you can store them in [output parameters](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter), e.g.:
+
+```yaml
+- id: versions
+  name: Get versions
+  run: |
+    echo "::set-output name=node-version::$(node --version)"
+    echo "::set-output name=npm-version::$(npm --version)"
+```


### PR DESCRIPTION
**Description:**
Is it worth adding to the advanced usage docs, some examples of how to get the resolved Node.js and npm versions?

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.