### PR TITLE
docs: Include warning when configuring token to install private packages

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -248,4 +248,4 @@ steps:
 - run: npm rebuild && npm run prepare --if-present
 ```
 
-NOTE: As per https://github.com/actions/setup-node/issues/49 you cannot use `secrets.GITHUB_TOKEN` to access private GitHub Packages within the same organisation.
+NOTE: As per https://github.com/actions/setup-node/issues/49 you cannot use `secrets.GITHUB_TOKEN` to access private GitHub Packages within the same organisation but in a different repository.

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -247,3 +247,5 @@ steps:
 # `npm rebuild` will run all those post-install scripts for us.
 - run: npm rebuild && npm run prepare --if-present
 ```
+
+NOTE: As per https://github.com/actions/setup-node/issues/49 you cannot use `secrets.GITHUB_TOKEN` to access private GitHub Packages within the same organisation.


### PR DESCRIPTION
The distinction between `secrets.GITHUB_TOKEN` and `secrets.NPM_TOKEN` cost myself and a colleague numerous hours when we were trying to fix a GitHub Actions workflow which needed to install a private package from a different repository from our GitHub organisation.

Given the issue dedicated to this point is closed, we should include a warning here to make it more clear why `secrets.GITHUB_TOKEN` will not work when passed to `npm ci`, in the presence of private packages from other GitHub Package repositories.

**Description:**
Describe your changes.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.