### PR TITLE
Fix: validate cached version

### DIFF
--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -225,7 +225,7 @@ describe('setup-node', () => {
     await main.run();
 
     expect(logSpy).toHaveBeenCalledWith(
-      `Found v14.0.0 in cache @ ${toolPath} but it does not satisfy the requested version (12.16.2)`
+      `Found v14.0.0 in cache @ ${expPath} but it does not satisfy the requested version (12.16.2)`
     );
     expect(logSpy).toHaveBeenCalledWith(
       `Attempting to download ${versionSpec}...`

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -205,6 +205,27 @@ describe('setup-node', () => {
     expect(cnSpy).toHaveBeenCalledWith(`::add-path::${expPath}${osm.EOL}`);
   });
 
+  it('finds incorrect version in cache and adds it to the path', async () => {
+    let versionSpec = '12.16.2';
+    inputs['node-version'] = versionSpec;
+
+    inSpy.mockImplementation(name => inputs[name]);
+    getExecOutputSpy.mockImplementation(() => 'v12.0.0');
+
+    let toolPath = path.normalize('/cache/node/12.16.1/x64');
+    findSpy.mockImplementation(() => toolPath);
+    await main.run();
+
+    let expPath = path.join(toolPath, 'bin');
+    expect(logSpy).toHaveBeenCalledWith(
+      `Found v12.0.0 in cache @ ${toolPath} but it does not satisfy the requested version (${versionSpec})`
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      `Attempting to download ${versionSpec}...`
+    );
+    expect(cnSpy).toHaveBeenCalledWith(`::add-path::${expPath}${osm.EOL}`);
+  });
+
   it('handles unhandled find error and reports error', async () => {
     let errMsg = 'unhandled error message';
     inputs['node-version'] = '12';

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -71448,11 +71448,16 @@ function getNode(versionSpec, stable, checkLatest, auth, arch = os.arch()) {
         // If not found in cache, download
         if (toolPath) {
             core.info(`Found in cache @ ${toolPath}`);
-            const { stdout: installedVersion } = yield exec.getExecOutput('node', ['--version'], { ignoreReturnCode: true });
-            if (!semver.satisfies(installedVersion, versionSpec)) {
-                core.info(`Found ${installedVersion} in cache @ ${toolPath} but it does not satisfy the requested version (${versionSpec})`);
-                toolPath = '';
+            if (osPlat != 'win32') {
+                toolPath = path.join(toolPath, 'bin');
             }
+            core.addPath(toolPath);
+            const { stdout: installedVersion } = yield exec.getExecOutput('node', ['--version'], { ignoreReturnCode: true });
+            if (semver.satisfies(installedVersion, versionSpec)) {
+                return;
+            }
+            core.info(`Found ${installedVersion} in cache @ ${toolPath} but it does not satisfy the requested version (${versionSpec})`);
+            toolPath = '';
         }
         if (!toolPath) {
             core.info(`Attempting to download ${versionSpec}...`);

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -71409,6 +71409,7 @@ const core = __importStar(__nccwpck_require__(2186));
 const hc = __importStar(__nccwpck_require__(9925));
 const io = __importStar(__nccwpck_require__(7436));
 const tc = __importStar(__nccwpck_require__(7784));
+const exec = __importStar(__nccwpck_require__(1514));
 const path = __importStar(__nccwpck_require__(1017));
 const semver = __importStar(__nccwpck_require__(5911));
 const fs = __nccwpck_require__(7147);
@@ -71447,8 +71448,13 @@ function getNode(versionSpec, stable, checkLatest, auth, arch = os.arch()) {
         // If not found in cache, download
         if (toolPath) {
             core.info(`Found in cache @ ${toolPath}`);
+            const { stdout: installedVersion } = yield exec.getExecOutput('node', ['--version'], { ignoreReturnCode: true });
+            if (!semver.satisfies(installedVersion, versionSpec)) {
+                core.info(`Found ${installedVersion} in cache @ ${toolPath} but it does not satisfy the requested version (${versionSpec})`);
+                toolPath = '';
+            }
         }
-        else {
+        if (!toolPath) {
             core.info(`Attempting to download ${versionSpec}...`);
             let downloadPath = '';
             let info = null;

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -82,18 +82,25 @@ export async function getNode(
   if (toolPath) {
     core.info(`Found in cache @ ${toolPath}`);
 
+    if (osPlat != 'win32') {
+      toolPath = path.join(toolPath, 'bin');
+    }
+
+    core.addPath(toolPath);
+
     const {stdout: installedVersion} = await exec.getExecOutput(
       'node',
       ['--version'],
       {ignoreReturnCode: true}
     );
 
-    if (!semver.satisfies(installedVersion, versionSpec)) {
-      core.info(
-        `Found ${installedVersion} in cache @ ${toolPath} but it does not satisfy the requested version (${versionSpec})`
-      );
-      toolPath = '';
+    if (semver.satisfies(installedVersion, versionSpec)) {
+      return;
     }
+    core.info(
+      `Found ${installedVersion} in cache @ ${toolPath} but it does not satisfy the requested version (${versionSpec})`
+    );
+    toolPath = '';
   }
 
   if (!toolPath) {


### PR DESCRIPTION
**Description:**

Validates the cached binary version against the versionSpec. If it doesn't match, then try to re-download.

**Related issue:**
[Related issue](https://github.com/actions/setup-node/issues/541)

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.