### PR TITLE
Fixing pnpm output issue

### DIFF
--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -59931,7 +59931,7 @@ exports.supportedPackageManagers = {
     },
     pnpm: {
         lockFilePatterns: ['pnpm-lock.yaml'],
-        getCacheFolderCommand: 'pnpm store path'
+        getCacheFolderCommand: 'pnpm store path --silent'
     },
     yarn1: {
         lockFilePatterns: ['yarn.lock'],
@@ -59986,7 +59986,7 @@ exports.getCacheDirectoryPath = (packageManagerInfo, packageManager) => __awaite
         throw new Error(`Could not get cache folder path for ${packageManager}`);
     }
     core.debug(`${packageManager} path is ${stdOut}`);
-    return stdOut;
+    return stdOut.trim();
 });
 function isGhes() {
     const ghUrl = new URL(process.env['GITHUB_SERVER_URL'] || 'https://github.com');

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -71277,7 +71277,7 @@ exports.supportedPackageManagers = {
     },
     pnpm: {
         lockFilePatterns: ['pnpm-lock.yaml'],
-        getCacheFolderCommand: 'pnpm store path'
+        getCacheFolderCommand: 'pnpm store path --silent'
     },
     yarn1: {
         lockFilePatterns: ['yarn.lock'],
@@ -71332,7 +71332,7 @@ exports.getCacheDirectoryPath = (packageManagerInfo, packageManager) => __awaite
         throw new Error(`Could not get cache folder path for ${packageManager}`);
     }
     core.debug(`${packageManager} path is ${stdOut}`);
-    return stdOut;
+    return stdOut.trim();
 });
 function isGhes() {
     const ghUrl = new URL(process.env['GITHUB_SERVER_URL'] || 'https://github.com');

--- a/src/cache-utils.ts
+++ b/src/cache-utils.ts
@@ -18,7 +18,7 @@ export const supportedPackageManagers: SupportedPackageManagers = {
   },
   pnpm: {
     lockFilePatterns: ['pnpm-lock.yaml'],
-    getCacheFolderCommand: 'pnpm store path'
+    getCacheFolderCommand: 'pnpm store path --silent'
   },
   yarn1: {
     lockFilePatterns: ['yarn.lock'],
@@ -94,7 +94,7 @@ export const getCacheDirectoryPath = async (
 
   core.debug(`${packageManager} path is ${stdOut}`);
 
-  return stdOut;
+  return stdOut.trim();
 };
 
 export function isGhes(): boolean {


### PR DESCRIPTION
**Description:**
In scope of this pull request we fix pnpm output issue. In some cases it can return extra output for getting path. For example:
```
Using hooks from: /home/runner/work/vite-plugin-svelte/vite-plugin-svelte/.pnpmfile.cjs
readPackage hook is declared. Manifests of dependencies might get overridden
/home/runner/.local/share/pnpm/store/v3
```
It can be fixed with adding --silent option

**Related issue:**
https://github.com/actions/setup-node/issues/543

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.