### PR TITLE
Set package manager versions

### DIFF
--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -17,7 +17,7 @@ export async function run() {
     const cacheLock = core.getInput('cache');
     await cachePackages(cacheLock);
   } catch (error) {
-    core.setFailed(error.message);
+    core.setFailed((error as Error).message);
   }
 }
 

--- a/src/cache-utils.ts
+++ b/src/cache-utils.ts
@@ -47,17 +47,35 @@ export const getCommandOutput = async (toolCommand: string) => {
   return stdout.trim();
 };
 
+const resolvePackageManagerVersionInput = (
+  packageManager: string
+): string | undefined => {
+  let version = core.getInput(`${packageManager}-version`);
+
+  if (version !== '') {
+    core.info(`Using ${packageManager} with version ${version}.`);
+
+    return version;
+  }
+};
+
 const getPackageManagerVersion = async (
   packageManager: string,
   command: string
 ) => {
-  const stdOut = await getCommandOutput(`${packageManager} ${command}`);
+  let packageManagerVersion = resolvePackageManagerVersionInput(packageManager);
 
-  if (!stdOut) {
-    throw new Error(`Could not retrieve version of ${packageManager}`);
+  if (packageManagerVersion) {
+    return packageManagerVersion;
+  } else {
+    const stdOut = await getCommandOutput(`${packageManager} ${command}`);
+
+    if (!stdOut) {
+      throw new Error(`Could not retrieve version of ${packageManager}`);
+    }
+
+    return stdOut;
   }
-
-  return stdOut;
 };
 
 export const getPackageManagerInfo = async (packageManager: string) => {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -116,9 +116,9 @@ export async function getNode(
           `Received HTTP status code ${err.httpStatusCode}.  This usually indicates the rate limit has been exceeded`
         );
       } else {
-        core.info(err.message);
+        core.info((err as Error).message);
       }
-      core.debug(err.stack);
+      core.debug((err as Error).stack!);
       core.info('Falling back to download directly from Node');
     }
 
@@ -334,7 +334,7 @@ async function resolveVersionFromManifest(
     return info?.resolvedVersion;
   } catch (err) {
     core.info('Unable to resolve version from manifest...');
-    core.debug(err.message);
+    core.debug((err as Error).message);
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,7 +72,7 @@ export async function run() {
       `##[add-matcher]${path.join(matchersPath, 'eslint-compact.json')}`
     );
   } catch (err) {
-    core.setFailed(err.message);
+    core.setFailed((err as Error).message);
   }
 }
 


### PR DESCRIPTION
**Description:**
Added support for specifying package manager versions in the workflow file just as specifying node version.
This only added support for the package managers that are supported by this GitHub action and in this case these are `npm`, `pnpm`, `yarn`.

**Related issue:**
#529 

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.