### PR TITLE
Add caveat for Yarn 2+ and private repos

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -250,7 +250,7 @@ steps:
 ### Yarn2 configuration
 Yarn2 ignores both .npmrc and .yarnrc files created by the action, so before installing dependencies from the private repo it is necessary either to create or to modify existing yarnrc.yml file with `yarn config set` commands.
 
-Below there's a sample "Setup .yarnrc.yml" step to configure private github registy for `my-org` organisation.
+Below you can find a sample "Setup .yarnrc.yml" step, that is going to allow you to configure a private GitHub registry for 'my-org' organisation.
 
 ```yaml
 steps:

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -247,5 +247,25 @@ steps:
 # `npm rebuild` will run all those post-install scripts for us.
 - run: npm rebuild && npm run prepare --if-present
 ```
+### Yarn2 configuration
+Yarn2 ignores both .npmrc and .yarnrc files created by the action, so before installing dependencies from the private repo it is necessary either to create or to modify existing yarnrc.yml file with `yarn config set` commands.
 
+Below there's a sample "Setup .yarnrc.yml" step to configure private github registy for `my-org` organisation.
+
+```yaml
+steps:
+- uses: actions/checkout@v3
+- uses: actions/setup-node@v3
+  with:
+    node-version: '14.x'
+- name: Setup .yarnrc.yml
+  run: |
+    yarn config set npmScopes.my-org.npmRegistryServer "https://npm.pkg.github.com"
+    yarn config set npmScopes.my-org.npmAlwaysAuth true
+    yarn config set npmScopes.my-org.npmAuthToken $NPM_AUTH_TOKEN
+  env:
+    NPM_AUTH_TOKEN: ${{ secrets.YARN_TOKEN }}
+- name: Install dependencies
+  run: yarn install --immutable
+```
 NOTE: As per https://github.com/actions/setup-node/issues/49 you cannot use `secrets.GITHUB_TOKEN` to access private GitHub Packages within the same organisation but in a different repository.


### PR DESCRIPTION
**Description:**
Yarn 2+ ignores both .npmrc and .yarnrc files so any auth settings via setup-node are ignored when using Yarn 2+. The additional configuration is necessary. 

**Related issue:**
[Add link to the related issue.](https://github.com/actions/setup-node/issues/537)

sample build: https://github.com/akv-demo/setup-node-test/actions/runs/2888635486

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.