### PR TITLE
Remove node 12 from matrix for yarn 1 cache 

### DIFF
--- a/.github/workflows/e2e-cache.yml
+++ b/.github/workflows/e2e-cache.yml
@@ -75,7 +75,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [12, 14, 16]
+        node-version: [14, 16]
     steps:
       - uses: actions/checkout@v3
       - name: Yarn version


### PR DESCRIPTION
**Description:**
In scope of this pull request we remove node 12 from matrix for yarn 1 cache because the library does not support node 12. 
**Related issue:**

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.