### PR TITLE
Get rid of warnings for set-output

### DIFF
--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Get node version
         run: |
           latestNodeVersion=$(curl https://nodejs.org/dist/index.json | jq -r '. [0].version')
-          echo "::set-output name=LATEST_NODE_VERSION::$latestNodeVersion"
+          echo "LATEST_NODE_VERSION=$latestNodeVersion" >> $GITHUB_OUTPUT
         id: version
         shell: bash
       - uses: actions/checkout@v3
@@ -189,7 +189,7 @@ jobs:
       - name: Retrieve version after install
         run: |
           updatedVersion=$(echo $(node --version))
-          echo "::set-output name=NODE_VERSION_UPDATED::$updatedVersion"
+          echo "NODE_VERSION_UPDATED=$updatedVersion" >> $GITHUB_OUTPUT
         id: updatedVersion
         shell: bash
       - name: Compare versions


### PR DESCRIPTION
**Description:**
In scope of this pull request we change deprecating commands. 

**Related issue:**
https://github.com/actions/setup-node/issues/606

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.