### PR TITLE
feat: add node-lts-codename output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,8 @@ outputs:
     description: 'A boolean value to indicate if a cache was hit.'
   node-version:
     description: 'The installed node version.'
+  node-lts-codename:
+    description: "The installed node version's LTS Codename. Empty if the installed node release is not an LTS release."
 runs:
   using: 'node16'
   main: 'dist/setup/index.js'

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -73683,6 +73683,9 @@ function printEnvDetailsAndSetOutput() {
             }
             core.info(`${tool}: ${output}`);
         }));
+        promises.push(getLtsCodename().then(codename => {
+            core.setOutput('node-lts-codename', codename);
+        }));
         yield Promise.all(promises);
         core.endGroup();
     });
@@ -73692,6 +73695,24 @@ function getToolVersion(tool, options) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const { stdout, stderr, exitCode } = yield exec.getExecOutput(tool, options, {
+                ignoreReturnCode: true,
+                silent: true
+            });
+            if (exitCode > 0) {
+                core.warning(`[warning]${stderr}`);
+                return '';
+            }
+            return stdout;
+        }
+        catch (err) {
+            return '';
+        }
+    });
+}
+function getLtsCodename() {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            const { stdout, stderr, exitCode } = yield exec.getExecOutput('node', ["-p 'process.release.lts || process.exit(0)'"], {
                 ignoreReturnCode: true,
                 silent: true
             });

--- a/src/main.ts
+++ b/src/main.ts
@@ -115,6 +115,12 @@ export async function printEnvDetailsAndSetOutput() {
     core.info(`${tool}: ${output}`);
   });
 
+  promises.push(
+    getLtsCodename().then(codename => {
+      core.setOutput('node-lts-codename', codename);
+    })
+  );
+
   await Promise.all(promises);
 
   core.endGroup();
@@ -126,6 +132,28 @@ async function getToolVersion(tool: string, options: string[]) {
       ignoreReturnCode: true,
       silent: true
     });
+
+    if (exitCode > 0) {
+      core.warning(`[warning]${stderr}`);
+      return '';
+    }
+
+    return stdout;
+  } catch (err) {
+    return '';
+  }
+}
+
+async function getLtsCodename() {
+  try {
+    const {stdout, stderr, exitCode} = await exec.getExecOutput(
+      'node',
+      ["-p 'process.release.lts || process.exit(0)'"],
+      {
+        ignoreReturnCode: true,
+        silent: true
+      }
+    );
 
     if (exitCode > 0) {
       core.warning(`[warning]${stderr}`);


### PR DESCRIPTION
**Description:**
Adds the installed node's [LTS Codename](https://nodejs.org/api/process.html#processrelease) (or lack of) to the action's output.

**Related issue:**
Don't have an open issue but I find myself in need of this output to determine if a given job should continue-on-error or not irrespective of what my node-version input format was.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.