### PR TITLE
Fix missing Docker image

### DIFF
--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -19,7 +19,7 @@ jobs:
       options: --dns 127.0.0.1
     services:
       squid-proxy:
-        image: datadog/squid:latest
+        image: ubuntu/squid:latest
         ports:
           - 3128:3128
     env:


### PR DESCRIPTION
**Description:**
In scope of this pull request we change `datadog/squid` to `ubuntu/squid` because `datadog/squid` does not exist
**Related issue:**

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.