### PR TITLE
Trim newline character in version output

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -73723,7 +73723,7 @@ function getToolVersion(tool, options) {
                 core.warning(`[warning]${stderr}`);
                 return '';
             }
-            return stdout;
+            return stdout.trim();
         }
         catch (err) {
             return '';

--- a/src/main.ts
+++ b/src/main.ts
@@ -132,7 +132,7 @@ async function getToolVersion(tool: string, options: string[]) {
       return '';
     }
 
-    return stdout;
+    return stdout.trim();
   } catch (err) {
     return '';
   }


### PR DESCRIPTION
**Description:**
Currently an extra newline character is included in the step output that causes some client's build to break

Proof: https://github.com/akv-demo/setup-node-test/actions/runs/3481914434/jobs/5823607442#step:4:42
Fix: https://github.com/akv-demo/setup-node-test/actions/runs/3481914434/jobs/5823607442#step:6:38

**Related issue:**
https://github.com/actions/setup-node/issues/618

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.