### PR TITLE
feat(cache) use restoreKeys as backup to hit cache

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -73021,9 +73021,11 @@ exports.restoreCache = (packageManager, cacheDependencyPath) => __awaiter(void 0
         throw new Error('Some specified paths were not resolved, unable to cache dependencies.');
     }
     const primaryKey = `node-cache-${platform}-${packageManager}-${fileHash}`;
+    const restoreKeys = [`node-cache-${platform}-${packageManager}-`];
     core.debug(`primary key is ${primaryKey}`);
+    core.debug(`restore keys are [${restoreKeys}]`);
     core.saveState(constants_1.State.CachePrimaryKey, primaryKey);
-    const cacheKey = yield cache.restoreCache([cachePath], primaryKey);
+    const cacheKey = yield cache.restoreCache([cachePath], primaryKey, restoreKeys);
     core.setOutput('cache-hit', Boolean(cacheKey));
     if (!cacheKey) {
         core.info(`${packageManager} cache is not found`);

--- a/src/cache-restore.ts
+++ b/src/cache-restore.ts
@@ -37,11 +37,13 @@ export const restoreCache = async (
   }
 
   const primaryKey = `node-cache-${platform}-${packageManager}-${fileHash}`;
+  const restoreKeys = [`node-cache-${platform}-${packageManager}-`];
   core.debug(`primary key is ${primaryKey}`);
+  core.debug(`restore keys are [${restoreKeys}]`);
 
   core.saveState(State.CachePrimaryKey, primaryKey);
 
-  const cacheKey = await cache.restoreCache([cachePath], primaryKey);
+  const cacheKey = await cache.restoreCache([cachePath], primaryKey, restoreKeys);
   core.setOutput('cache-hit', Boolean(cacheKey));
 
   if (!cacheKey) {

--- a/src/cache-restore.ts
+++ b/src/cache-restore.ts
@@ -43,7 +43,11 @@ export const restoreCache = async (
 
   core.saveState(State.CachePrimaryKey, primaryKey);
 
-  const cacheKey = await cache.restoreCache([cachePath], primaryKey, restoreKeys);
+  const cacheKey = await cache.restoreCache(
+    [cachePath],
+    primaryKey,
+    restoreKeys
+  );
   core.setOutput('cache-hit', Boolean(cacheKey));
 
   if (!cacheKey) {


### PR DESCRIPTION
**Description:**
Add restoreKeys to find cache. When lockfile has changed the primary key will not find the cache. Though using the most recent one in the branch scope should still be an improvement.

~As this is a feature in the actions toolkit, I am not sure additional tests should be added. In case you think it should, maybe it is best for the maintainers to do it.~
I do see that the test need to be extended. Maybe it is best for the maintainers to do it.

**Related issue:**
Fixes https://github.com/actions/setup-node/issues/627

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.