### PR TITLE
Fix scoped registries are duplicated in npmrc

### DIFF
--- a/__tests__/authutil.test.ts
+++ b/__tests__/authutil.test.ts
@@ -123,6 +123,7 @@ describe('authutil tests', () => {
     expect(rc['registry']).toBe('https://registry.npmjs.org/');
     expect(rc['always-auth']).toBe('true');
   });
+
   it('It is already set the NODE_AUTH_TOKEN export it ', async () => {
     process.env.NODE_AUTH_TOKEN = 'foobar';
     await auth.configAuthentication('npm.pkg.github.com', 'false');
@@ -131,5 +132,85 @@ describe('authutil tests', () => {
     expect(rc['@ownername:registry']).toBe('npm.pkg.github.com/');
     expect(rc['always-auth']).toBe('false');
     expect(process.env.NODE_AUTH_TOKEN).toEqual('foobar');
+  });
+
+  it('configAuthentication should overwrite non-scoped with non-scoped', async () => {
+    fs.writeFileSync(rcFile, 'registry=NNN');
+    await auth.configAuthentication('https://registry.npmjs.org/', 'true');
+    let contents = fs.readFileSync(rcFile, {encoding: 'utf8'});
+    expect(contents).toBe(
+      `//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}registry=https://registry.npmjs.org/${os.EOL}always-auth=true`
+    );
+  });
+
+  it('configAuthentication should overwrite only non-scoped', async () => {
+    fs.writeFileSync(rcFile, `registry=NNN${os.EOL}@myscope:registry=MMM`);
+    await auth.configAuthentication('https://registry.npmjs.org/', 'true');
+    let contents = fs.readFileSync(rcFile, {encoding: 'utf8'});
+    expect(contents).toBe(
+      `@myscope:registry=MMM${os.EOL}//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}registry=https://registry.npmjs.org/${os.EOL}always-auth=true`
+    );
+  });
+
+  it('configAuthentication should add non-scoped to scoped', async () => {
+    fs.writeFileSync(rcFile, '@myscope:registry=NNN');
+    await auth.configAuthentication('https://registry.npmjs.org/', 'true');
+    let contents = fs.readFileSync(rcFile, {encoding: 'utf8'});
+    expect(contents).toBe(
+      `@myscope:registry=NNN${os.EOL}//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}registry=https://registry.npmjs.org/${os.EOL}always-auth=true`
+    );
+  });
+
+  it('configAuthentication should overwrite scoped with scoped', async () => {
+    process.env['INPUT_SCOPE'] = 'myscope';
+    fs.writeFileSync(rcFile, `@myscope:registry=NNN`);
+    await auth.configAuthentication('https://registry.npmjs.org/', 'true');
+    let contents = fs.readFileSync(rcFile, {encoding: 'utf8'});
+    expect(contents).toBe(
+      `//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}@myscope:registry=https://registry.npmjs.org/${os.EOL}always-auth=true`
+    );
+  });
+
+  it('configAuthentication should overwrite only scoped', async () => {
+    process.env['INPUT_SCOPE'] = 'myscope';
+    fs.writeFileSync(rcFile, `registry=NNN${os.EOL}@myscope:registry=MMM`);
+    await auth.configAuthentication('https://registry.npmjs.org/', 'true');
+    let contents = fs.readFileSync(rcFile, {encoding: 'utf8'});
+    expect(contents).toBe(
+      `registry=NNN${os.EOL}//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}@myscope:registry=https://registry.npmjs.org/${os.EOL}always-auth=true`
+    );
+  });
+
+  it('configAuthentication should add scoped to non-scoped', async () => {
+    process.env['INPUT_SCOPE'] = 'myscope';
+    fs.writeFileSync(rcFile, `registry=MMM`);
+    await auth.configAuthentication('https://registry.npmjs.org/', 'true');
+    let contents = fs.readFileSync(rcFile, {encoding: 'utf8'});
+    expect(contents).toBe(
+      `registry=MMM${os.EOL}//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}@myscope:registry=https://registry.npmjs.org/${os.EOL}always-auth=true`
+    );
+  });
+
+  it('configAuthentication should overwrite only one scoped', async () => {
+    process.env['INPUT_SCOPE'] = 'myscope';
+    fs.writeFileSync(
+      rcFile,
+      `@otherscope:registry=NNN${os.EOL}@myscope:registry=MMM`
+    );
+    await auth.configAuthentication('https://registry.npmjs.org/', 'true');
+    let contents = fs.readFileSync(rcFile, {encoding: 'utf8'});
+    expect(contents).toBe(
+      `@otherscope:registry=NNN${os.EOL}//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}@myscope:registry=https://registry.npmjs.org/${os.EOL}always-auth=true`
+    );
+  });
+
+  it('configAuthentication should add scoped to another scoped', async () => {
+    process.env['INPUT_SCOPE'] = 'myscope';
+    fs.writeFileSync(rcFile, `@otherscope:registry=MMM`);
+    await auth.configAuthentication('https://registry.npmjs.org/', 'true');
+    let contents = fs.readFileSync(rcFile, {encoding: 'utf8'});
+    expect(contents).toBe(
+      `@otherscope:registry=MMM${os.EOL}//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}@myscope:registry=https://registry.npmjs.org/${os.EOL}always-auth=true`
+    );
   });
 });

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -72945,7 +72945,7 @@ function writeRegistryToFile(registryUrl, fileLocation, alwaysAuth) {
         scope = '@' + scope;
     }
     if (scope) {
-        scope = scope.toLowerCase();
+        scope = scope.toLowerCase() + ':';
     }
     core.debug(`Setting auth in ${fileLocation}`);
     let newContents = '';
@@ -72953,16 +72953,14 @@ function writeRegistryToFile(registryUrl, fileLocation, alwaysAuth) {
         const curContents = fs.readFileSync(fileLocation, 'utf8');
         curContents.split(os.EOL).forEach((line) => {
             // Add current contents unless they are setting the registry
-            if (!line.toLowerCase().startsWith('registry')) {
+            if (!line.toLowerCase().startsWith(`${scope}registry`)) {
                 newContents += line + os.EOL;
             }
         });
     }
     // Remove http: or https: from front of registry.
     const authString = registryUrl.replace(/(^\w+:|^)/, '') + ':_authToken=${NODE_AUTH_TOKEN}';
-    const registryString = scope
-        ? `${scope}:registry=${registryUrl}`
-        : `registry=${registryUrl}`;
+    const registryString = `${scope}registry=${registryUrl}`;
     const alwaysAuthString = `always-auth=${alwaysAuth}`;
     newContents += `${authString}${os.EOL}${registryString}${os.EOL}${alwaysAuthString}`;
     fs.writeFileSync(fileLocation, newContents);

--- a/src/authutil.ts
+++ b/src/authutil.ts
@@ -29,7 +29,7 @@ function writeRegistryToFile(
     scope = '@' + scope;
   }
   if (scope) {
-    scope = scope.toLowerCase();
+    scope = scope.toLowerCase() + ':';
   }
 
   core.debug(`Setting auth in ${fileLocation}`);
@@ -38,7 +38,7 @@ function writeRegistryToFile(
     const curContents: string = fs.readFileSync(fileLocation, 'utf8');
     curContents.split(os.EOL).forEach((line: string) => {
       // Add current contents unless they are setting the registry
-      if (!line.toLowerCase().startsWith('registry')) {
+      if (!line.toLowerCase().startsWith(`${scope}registry`)) {
         newContents += line + os.EOL;
       }
     });
@@ -46,9 +46,7 @@ function writeRegistryToFile(
   // Remove http: or https: from front of registry.
   const authString: string =
     registryUrl.replace(/(^\w+:|^)/, '') + ':_authToken=${NODE_AUTH_TOKEN}';
-  const registryString: string = scope
-    ? `${scope}:registry=${registryUrl}`
-    : `registry=${registryUrl}`;
+  const registryString: string = `${scope}registry=${registryUrl}`;
   const alwaysAuthString: string = `always-auth=${alwaysAuth}`;
   newContents += `${authString}${os.EOL}${registryString}${os.EOL}${alwaysAuthString}`;
   fs.writeFileSync(fileLocation, newContents);


### PR DESCRIPTION
**Description:**
auth.ts is modified to not duplicate scoped registry entries is nnpmrc

**Related issue:**
[Add link to the related issue.](https://github.com/actions/setup-node/issues/615)

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.