### PR TITLE
Use early return pattern to avoid nested conditions

### DIFF
--- a/__tests__/cache-utils.test.ts
+++ b/__tests__/cache-utils.test.ts
@@ -46,7 +46,8 @@ describe('cache-utils', () => {
     isFeatureAvailable.mockImplementation(() => false);
     process.env['GITHUB_SERVER_URL'] = 'https://www.test.com';
 
-    expect(() => isCacheFeatureAvailable()).toThrowError(
+    expect(isCacheFeatureAvailable()).toBeFalsy();
+    expect(warningSpy).toHaveBeenCalledWith(
       'Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.'
     );
   });

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -728,8 +728,9 @@ describe('setup-node', () => {
 
       await main.run();
 
-      expect(cnSpy).toHaveBeenCalledWith(
-        `::error::Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.${osm.EOL}`
+      expect(warningSpy).toHaveBeenCalledWith(
+        //  `::error::Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.${osm.EOL}`
+        'Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.'
       );
     });
 

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -61187,8 +61187,10 @@ exports.isGhes = isGhes;
 function isCacheFeatureAvailable() {
     if (cache.isFeatureAvailable())
         return true;
-    if (isGhes())
-        throw new Error('Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.');
+    if (isGhes()) {
+        core.warning('Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.');
+        return false;
+    }
     core.warning('The runner was not able to contact the cache service. Caching will be skipped');
     return false;
 }

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -61185,16 +61185,12 @@ function isGhes() {
 }
 exports.isGhes = isGhes;
 function isCacheFeatureAvailable() {
-    if (!cache.isFeatureAvailable()) {
-        if (isGhes()) {
-            throw new Error('Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.');
-        }
-        else {
-            core.warning('The runner was not able to contact the cache service. Caching will be skipped');
-        }
-        return false;
-    }
-    return true;
+    if (cache.isFeatureAvailable())
+        return true;
+    if (isGhes())
+        throw new Error('Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.');
+    core.warning('The runner was not able to contact the cache service. Caching will be skipped');
+    return false;
 }
 exports.isCacheFeatureAvailable = isCacheFeatureAvailable;
 

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -73139,16 +73139,12 @@ function isGhes() {
 }
 exports.isGhes = isGhes;
 function isCacheFeatureAvailable() {
-    if (!cache.isFeatureAvailable()) {
-        if (isGhes()) {
-            throw new Error('Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.');
-        }
-        else {
-            core.warning('The runner was not able to contact the cache service. Caching will be skipped');
-        }
-        return false;
-    }
-    return true;
+    if (cache.isFeatureAvailable())
+        return true;
+    if (isGhes())
+        throw new Error('Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.');
+    core.warning('The runner was not able to contact the cache service. Caching will be skipped');
+    return false;
 }
 exports.isCacheFeatureAvailable = isCacheFeatureAvailable;
 

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -73141,8 +73141,10 @@ exports.isGhes = isGhes;
 function isCacheFeatureAvailable() {
     if (cache.isFeatureAvailable())
         return true;
-    if (isGhes())
-        throw new Error('Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.');
+    if (isGhes()) {
+        core.warning('Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.');
+        return false;
+    }
     core.warning('The runner was not able to contact the cache service. Caching will be skipped');
     return false;
 }

--- a/src/cache-utils.ts
+++ b/src/cache-utils.ts
@@ -107,10 +107,12 @@ export function isGhes(): boolean {
 export function isCacheFeatureAvailable(): boolean {
   if (cache.isFeatureAvailable()) return true;
 
-  if (isGhes())
-    throw new Error(
+  if (isGhes()) {
+    core.warning(
       'Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.'
     );
+    return false;
+  }
 
   core.warning(
     'The runner was not able to contact the cache service. Caching will be skipped'

--- a/src/cache-utils.ts
+++ b/src/cache-utils.ts
@@ -105,19 +105,16 @@ export function isGhes(): boolean {
 }
 
 export function isCacheFeatureAvailable(): boolean {
-  if (!cache.isFeatureAvailable()) {
-    if (isGhes()) {
-      throw new Error(
-        'Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.'
-      );
-    } else {
-      core.warning(
-        'The runner was not able to contact the cache service. Caching will be skipped'
-      );
-    }
+  if (cache.isFeatureAvailable()) return true;
 
-    return false;
-  }
+  if (isGhes())
+    throw new Error(
+      'Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin if Actions cache service is enabled or not.'
+    );
 
-  return true;
+  core.warning(
+    'The runner was not able to contact the cache service. Caching will be skipped'
+  );
+
+  return false;
 }


### PR DESCRIPTION
**Description:**
Return early is the way of writing functions or methods so that the expected positive result is returned at the end of the function and the rest of the code terminates the execution (by returning or throwing an exception) when conditions are not met.



**Related issue:**
[related issue](https://github.com/actions/setup-node/issues/636).

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.