### PR TITLE
Option to enable corepack

### DIFF
--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -1253,6 +1253,44 @@ describe('setup-node', () => {
       }
     );
   });
+
+  describe('corepack flag', () => {
+    it('use corepack if specified', async () => {
+      inputs['corepack'] = 'true';
+      await main.run();
+      expect(getExecOutputSpy).toHaveBeenCalledWith(
+        'corepack',
+        ['enable'],
+        expect.anything()
+      );
+    });
+
+    it('use corepack with given package manager', async () => {
+      inputs['corepack'] = 'npm';
+      await main.run();
+      expect(getExecOutputSpy).toHaveBeenCalledWith(
+        'corepack',
+        ['enable', 'npm'],
+        expect.anything()
+      );
+    });
+
+    it('use corepack with multiple package managers', async () => {
+      inputs['corepack'] = 'npm yarn';
+      await main.run();
+      expect(getExecOutputSpy).toHaveBeenCalledWith(
+        'corepack',
+        ['enable', 'npm', 'yarn'],
+        expect.anything()
+      );
+    });
+
+    it('fails to use corepack with an invalid package manager', async () => {
+      await expect(im.enableCorepack('npm turbo')).rejects.toThrowError(
+        `One or more of the specified package managers [ npm turbo ] are not supported by corepack`
+      );
+    });
+  });
 });
 
 describe('helper methods', () => {

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
     description: 'Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm.'
   cache-dependency-path:
     description: 'Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc. Supports wildcards or a list of file names for caching multiple dependencies.'
+  corepack:
+    description: 'Used to specify whether to enable Corepack. Set to true to enable all package managers or set it to one or more package manager names (separate package manager names by a space. Supported package manager names: npm, yarn, pnpm.'
+    default: 'false'
 # TODO: add input to control forcing to pull from cloud or dist. 
 #       escape valve for someone having issues or needing the absolute latest which isn't cached yet
 outputs:

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -4,6 +4,7 @@ import * as core from '@actions/core';
 import * as hc from '@actions/http-client';
 import * as io from '@actions/io';
 import * as tc from '@actions/tool-cache';
+import * as exec from '@actions/exec';
 import * as path from 'path';
 import * as semver from 'semver';
 import fs from 'fs';
@@ -603,4 +604,22 @@ export function parseNodeVersionFile(contents: string): string {
 
 function isLatestSyntax(versionSpec): boolean {
   return ['current', 'latest', 'node'].includes(versionSpec);
+}
+
+export async function enableCorepack(input: string): Promise<void> {
+  let corepackArgs = ['enable'];
+  if (input.length > 0 && input !== 'false') {
+    if (input !== 'true') {
+      const packageManagers = input.split(' ');
+      if (!packageManagers.every(pm => ['npm', 'yarn', 'pnpm'].includes(pm))) {
+        throw new Error(
+          `One or more of the specified package managers [ ${input} ] are not supported by corepack`
+        );
+      }
+      corepackArgs.push(...packageManagers);
+    }
+    await exec.getExecOutput('corepack', corepackArgs, {
+      ignoreReturnCode: true
+    });
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,9 @@ export async function run() {
       auth.configAuthentication(registryUrl, alwaysAuth);
     }
 
+    const corepack = core.getInput('corepack') || 'false';
+    await installer.enableCorepack(corepack);
+
     if (cache && isCacheFeatureAvailable()) {
       const cacheDependencyPath = core.getInput('cache-dependency-path');
       await restoreCache(cache, cacheDependencyPath);


### PR DESCRIPTION
**Description:**
Adds the `corepack` option, which if `true` will run `corepack enable` to enable corepack. This option is by default `false` which ensures that there is no breaking change. Moreover, we can use a string of package manager names in place of `true` which will indicate to run `corepack enable <string of package manager names>`.

**Related issue:**
Closes #531 

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.