### PR TITLE
Update workflow badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![basic-validation](https://github.com/actions/setup-node/actions/workflows/basic-validation.yml/badge.svg)](https://github.com/actions/setup-node/actions/workflows/basic-validation.yml)
 [![versions](https://github.com/actions/setup-node/actions/workflows/versions.yml/badge.svg)](https://github.com/actions/setup-node/actions/workflows/versions.yml)
+[![e2e-cache](https://github.com/actions/setup-node/actions/workflows/e2e-cache.yml/badge.svg?branch=main)](https://github.com/actions/setup-node/actions/workflows/e2e-cache.yml)
 [![proxy](https://github.com/actions/setup-node/actions/workflows/proxy.yml/badge.svg)](https://github.com/actions/setup-node/actions/workflows/proxy.yml)
 
 This action provides the following functionality for GitHub Actions users:


### PR DESCRIPTION
**Description:**
In the scope of this PR, [workflow badges](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge) were updated to represent the current status of the workflows which test the action. The badges were organized like that:
1. Badge for a workflow with unit tests
2. Badges for other workflows with several e2e tests

Use `display the rich diff` button to see the visual representation of the changes:
![image](https://user-images.githubusercontent.com/98037481/215442456-56bd363d-897b-4111-bd37-1dcdfcb2bbc0.png)

**Related issue:**
https://github.com/actions/runner-images-internal/issues/4709