### PR TITLE
Fix description about ensuring workflow access to private package

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -401,11 +401,14 @@ steps:
     yarn config set npmScopes.my-org.npmAlwaysAuth true
     yarn config set npmScopes.my-org.npmAuthToken $NPM_AUTH_TOKEN
   env:
-    NPM_AUTH_TOKEN: ${{ secrets.YARN_TOKEN }}
+    NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 - name: Install dependencies
   run: yarn install --immutable
 ```
-NOTE: As per https://github.com/actions/setup-node/issues/49 you cannot use `secrets.GITHUB_TOKEN` to access private GitHub Packages within the same organisation but in a different repository.
+
+To access private GitHub Packages within the same organization, go to "Manage Actions access" in Package settings and set the repositories you want to access.
+
+Please refer to the [Ensuring workflow access to your package - Configuring a package's access control and visibility](https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility#ensuring-workflow-access-to-your-package) for more details.
 
 ### always-auth input
 The always-auth input sets `always-auth=true` in .npmrc file. With this option set [npm](https://docs.npmjs.com/cli/v6/using-npm/config#always-auth)/yarn sends the authentication credentials when making a request to the registries.


### PR DESCRIPTION
**Description:**
I modified it because going to packages settings gives me access to private GitHub packages from other repositories:

<img width="888" alt="스크린샷 2023-03-08 오후 5 53 44" src="https://user-images.githubusercontent.com/5278201/223670110-4b9e00c4-9040-48a7-90ad-68b977c2c260.png">

To access private GitHub Packages within the same organization, go to "Manage Actions access" in Package settings and set the repositories you want to access. and use [`GITHUB_TOKEN`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) as the NPM auth token.

Please refer to the [Ensuring workflow access to your package - Configuring a package's access control and visibility](https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility#ensuring-workflow-access-to-your-package) for more details.


**Related issue:**
#49

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.

