### PR TITLE
bugfix: Don't attempt to use Windows fallbacks on non-Windows OSes

### DIFF
--- a/__tests__/nightly-installer.test.ts
+++ b/__tests__/nightly-installer.test.ts
@@ -39,6 +39,7 @@ describe('setup-node', () => {
   let whichSpy: jest.SpyInstance;
   let existsSpy: jest.SpyInstance;
   let mkdirpSpy: jest.SpyInstance;
+  let cpSpy: jest.SpyInstance;
   let execSpy: jest.SpyInstance;
   let authSpy: jest.SpyInstance;
   let parseNodeVersionSpy: jest.SpyInstance;
@@ -51,6 +52,7 @@ describe('setup-node', () => {
     console.log('::stop-commands::stoptoken'); // Disable executing of runner commands when running tests in actions
     process.env['GITHUB_PATH'] = ''; // Stub out ENV file functionality so we can verify it writes to standard out
     process.env['GITHUB_OUTPUT'] = ''; // Stub out ENV file functionality so we can verify it writes to standard out
+    process.env['RUNNER_TEMP'] = '/runner_temp';
     inputs = {};
     inSpy = jest.spyOn(core, 'getInput');
     inSpy.mockImplementation(name => inputs[name]);
@@ -78,6 +80,7 @@ describe('setup-node', () => {
     whichSpy = jest.spyOn(io, 'which');
     existsSpy = jest.spyOn(fs, 'existsSync');
     mkdirpSpy = jest.spyOn(io, 'mkdirP');
+    cpSpy = jest.spyOn(io, 'cp');
 
     // @actions/tool-cache
     isCacheActionAvailable = jest.spyOn(cache, 'isFeatureAvailable');
@@ -271,6 +274,90 @@ describe('setup-node', () => {
     expect(dlSpy).toHaveBeenCalled();
     expect(exSpy).toHaveBeenCalled();
     expect(cnSpy).toHaveBeenCalledWith(`::add-path::${expPath}${osm.EOL}`);
+  });
+
+  it('windows: falls back to exe version if not in manifest and not in node dist', async () => {
+    os.platform = 'win32';
+    os.arch = 'x64';
+
+    // a version which is not in the manifest but is in node dist
+    const versionSpec = '13.13.1-nightly20200415947ddec091';
+
+    const workingUrls = [
+      `https://nodejs.org/download/nightly/v${versionSpec}/win-x64/node.exe`,
+      `https://nodejs.org/download/nightly/v${versionSpec}/win-x64/node.lib`
+    ]
+
+    inputs['node-version'] = versionSpec;
+    inputs['always-auth'] = false;
+    inputs['token'] = 'faketoken';
+
+    // ... but not in the local cache
+    findSpy.mockImplementation(() => '');
+    findAllVersionsSpy.mockImplementation(() => []);
+
+    dlSpy.mockImplementation(async (url) => {
+      if (workingUrls.includes(url)) {
+        return '/some/temp/path'
+      }
+
+      throw new tc.HTTPError(404)
+    });
+    const toolPath = path.normalize(
+      '/cache/node/13.13.1-nightly20200415947ddec091/x64'
+    );
+    cacheSpy.mockImplementation(async () => toolPath);
+    mkdirpSpy.mockImplementation(async () => {})
+    cpSpy.mockImplementation(async () => {})
+
+    await main.run();
+
+    workingUrls.forEach(url => {
+      expect(dlSpy).toHaveBeenCalledWith(url);
+    })
+    expect(cnSpy).toHaveBeenCalledWith(`::add-path::${toolPath}${osm.EOL}`);
+  });
+
+  it('linux: does not fall back to exe version if not in manifest and not in node dist', async () => {
+    os.platform = 'linux';
+    os.arch = 'x64';
+
+    // a version which is not in the manifest but is in node dist
+    const versionSpec = '13.13.1-nightly20200415947ddec091';
+
+    const workingUrls = [
+      `https://nodejs.org/download/nightly/v${versionSpec}/win-x64/node.exe`,
+      `https://nodejs.org/download/nightly/v${versionSpec}/win-x64/node.lib`
+    ]
+
+    inputs['node-version'] = versionSpec;
+    inputs['always-auth'] = false;
+    inputs['token'] = 'faketoken';
+
+    // ... but not in the local cache
+    findSpy.mockImplementation(() => '');
+    findAllVersionsSpy.mockImplementation(() => []);
+
+    dlSpy.mockImplementation(async (url) => {
+      if (workingUrls.includes(url)) {
+        return '/some/temp/path'
+      }
+
+      throw new tc.HTTPError(404)
+    });
+    const toolPath = path.normalize(
+      '/cache/node/13.13.1-nightly20200415947ddec091/x64'
+    );
+    cacheSpy.mockImplementation(async () => toolPath);
+    mkdirpSpy.mockImplementation(async () => {})
+    cpSpy.mockImplementation(async () => {})
+
+    await main.run();
+
+    workingUrls.forEach(url => {
+      expect(dlSpy).not.toHaveBeenCalledWith(url);
+    })
+    expect(cnSpy).toHaveBeenCalledWith(`::error::Unexpected HTTP response: 404${osm.EOL}`);
   });
 
   it('does not find a version that does not exist', async () => {

--- a/src/distributions/base-distribution.ts
+++ b/src/distributions/base-distribution.ts
@@ -127,8 +127,8 @@ export default abstract class BaseDistribution {
     try {
       downloadPath = await tc.downloadTool(info.downloadUrl);
     } catch (err) {
-      if (err instanceof tc.HTTPError && err.httpStatusCode == 404) {
-        return await this.acquireNodeFromFallbackLocation(
+      if (err instanceof tc.HTTPError && err.httpStatusCode == 404 && this.osPlat == 'win32') {
+        return await this.acquireWindowsNodeFromFallbackLocation(
           info.resolvedVersion,
           info.arch
         );
@@ -151,7 +151,7 @@ export default abstract class BaseDistribution {
     return {range: valid, options};
   }
 
-  protected async acquireNodeFromFallbackLocation(
+  protected async acquireWindowsNodeFromFallbackLocation(
     version: string,
     arch: string = os.arch()
   ): Promise<string> {


### PR DESCRIPTION
**Description:**
Currently if we're unable to get the .7z or .tar.gz file, we fallback to the .exe and .lib files. However, these are only intended to be used by Windows machines, and do not work on Linux or macOS. This PR corrects the behaviour of setup-node to only use this fallback if on Windows.

I've also added tests for this fallback functionality in general, as well as the regression test case that Linux should not attempt to download these files.

**Related issue:**
Fixes #714

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.