### PR TITLE
Fix glob bug in package.json scripts section

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "main": "lib/setup-node.js",
   "scripts": {
     "build": "ncc build -o dist/setup src/setup-node.ts && ncc build -o dist/cache-save src/cache-save.ts",
-    "format": "prettier --no-error-on-unmatched-pattern --config ./.prettierrc.js --write **/*.{ts,yml,yaml}",
-    "format-check": "prettier --no-error-on-unmatched-pattern --config ./.prettierrc.js --check **/*.{ts,yml,yaml}",
-    "lint": "eslint --config ./.eslintrc.js **/*.ts",
-    "lint:fix": "eslint --config ./.eslintrc.js **/*.ts --fix",
+    "format": "prettier --no-error-on-unmatched-pattern --config ./.prettierrc.js --write \"**/*.{ts,yml,yaml}\"",
+    "format-check": "prettier --no-error-on-unmatched-pattern --config ./.prettierrc.js --check \"**/*.{ts,yml,yaml}\"",
+    "lint": "eslint --config ./.eslintrc.js \"**/*.ts\"",
+    "lint:fix": "eslint --config ./.eslintrc.js \"**/*.ts\" --fix",
     "test": "jest --coverage",
     "pre-checkin": "npm run format && npm run lint:fix && npm run build && npm test"
   },


### PR DESCRIPTION
**Description:**
In the scope of this PR, we fix the bug related to the wrong interpretation of the glob patterns. Glob patterns that aren't wrapped by the quotes are opened and transformed into concrete paths by the shell used in the OS (e.g., PowerShell, bash. zsh, and so on). The behavior of this transformation is different for different shells, which can cause different behaviors of the tools. By wrapping glob patterns in double quotes, we prevent shell from opening and transforming them and instruct tool to do it instead.

**Related issue:**
https://github.com/actions/runner-images-internal/issues/4899