### PR TITLE
Do not ivalidate the cache entirely on lock file change

### DIFF
--- a/.github/workflows/e2e-cache.yml
+++ b/.github/workflows/e2e-cache.yml
@@ -146,7 +146,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: prepare sub-projects
-        run: __tests__/prepare-subprojects.sh
+        run: __tests__/prepare-yarn-subprojects.sh yarn1
 
       # expect
       #  - no errors
@@ -161,3 +161,85 @@ jobs:
           cache-dependency-path: |
             **/*.lock
             yarn.lock
+
+  yarn-subprojects-berry-local:
+    name: Test yarn subprojects all locally managed
+    strategy:
+      matrix:
+        node-version: [12, 14, 16]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: prepare sub-projects
+        run: __tests__/prepare-yarn-subprojects.sh
+
+      # expect
+      #  - no errors
+      #  - log
+      #    ##[info]All dependencies are managed locally by yarn3, the previous cache can be used
+      #    ##[debug]["node-cache-Linux-yarn-401024703386272f1a950c9f014cbb1bb79a7a5b6e1fb00e8b90d06734af41ee","node-cache-Linux-yarn"]
+      - name: Setup Node
+        uses: ./
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+          cache-dependency-path: |
+            sub2/*.lock
+            sub3/*.lock
+
+  yarn-subprojects-berry-global:
+    name: Test yarn subprojects some locally managed
+    strategy:
+      matrix:
+        node-version: [12, 14, 16]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: prepare sub-projects
+        run: __tests__/prepare-yarn-subprojects.sh global
+
+      # expect
+      #  - no errors
+      #  - log must
+      #    ##[debug]"/home/runner/work/setup-node-test/setup-node-test/sub2" dependencies are managed by yarn 3 locally
+      #    ##[debug]"/home/runner/work/setup-node-test/setup-node-test/sub3" dependencies are not managed by yarn 3 locally
+      - name: Setup Node
+        uses: ./
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+          cache-dependency-path: |
+            sub2/*.lock
+            sub3/*.lock
+
+  yarn-subprojects-berry-git:
+    name: Test yarn subprojects managed by git
+    strategy:
+      matrix:
+        node-version: [12, 14, 16]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: prepare sub-projects
+        run: /bin/bash __tests__/prepare-yarn-subprojects.sh keepcache
+
+      # expect
+      #  - no errors
+      #  - log
+      #    [debug]"/home/runner/work/setup-node-test/setup-node-test/sub2" has .yarn/cache - dependencies are kept in the repository
+      #    [debug]"/home/runner/work/setup-node-test/setup-node-test/sub3" has .yarn/cache - dependencies are kept in the repository
+      #    [debug]["node-cache-Linux-yarn-401024703386272f1a950c9f014cbb1bb79a7a5b6e1fb00e8b90d06734af41ee"]
+      - name: Setup Node
+        uses: ./
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+          cache-dependency-path: |
+            sub2/*.lock
+            sub3/*.lock

--- a/__tests__/cache-utils.test.ts
+++ b/__tests__/cache-utils.test.ts
@@ -6,7 +6,8 @@ import {
   PackageManagerInfo,
   isCacheFeatureAvailable,
   supportedPackageManagers,
-  getCommandOutput
+  getCommandOutput,
+  resetProjectDirectoriesMemoized
 } from '../src/cache-utils';
 import fs from 'fs';
 import * as cacheUtils from '../src/cache-utils';
@@ -103,6 +104,8 @@ describe('cache-utils', () => {
         (pattern: string): Promise<Globber> =>
           MockGlobber.create(['/foo', '/bar'])
       );
+
+      resetProjectDirectoriesMemoized();
     });
 
     afterEach(() => {

--- a/__tests__/prepare-yarn-subprojects.sh
+++ b/__tests__/prepare-yarn-subprojects.sh
@@ -32,10 +32,20 @@ cat <<EOT >package.json
 EOT
 yarn set version 3.5.1
 yarn install
+if [ x$1 = 'xglobal' ];then
+  echo enableGlobalCache
+  echo 'enableGlobalCache: true' >> .yarnrc.yml
+fi
 
-echo "create yarn1 project in the root"
 cd ..
-cat <<EOT >package.json
+if [ x$1 != 'xkeepcache' -a x$2 != 'xkeepcache' ]; then
+  rm -rf sub2/.yarn/cache
+  rm -rf sub3/.yarn/cache
+fi
+
+if [ x$1 = 'xyarn1' ];then
+  echo "create yarn1 project in the root"
+  cat <<EOT >package.json
 {
   "name": "subproject",
   "dependencies": {
@@ -44,5 +54,6 @@ cat <<EOT >package.json
   }
 }
 EOT
-yarn set version 1.22.19
-yarn install
+  yarn set version 1.22.19
+  yarn install
+fi

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -60434,7 +60434,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.isCacheFeatureAvailable = exports.isGhes = exports.repoHasYarn3ManagedCache = exports.getCacheDirectories = exports.resetProjectDirectoriesMemoized = exports.getPackageManagerInfo = exports.getCommandOutputNotEmpty = exports.getCommandOutput = exports.supportedPackageManagers = void 0;
+exports.isCacheFeatureAvailable = exports.isGhes = exports.repoHasYarnBerryManagedDependencies = exports.getCacheDirectories = exports.resetProjectDirectoriesMemoized = exports.getPackageManagerInfo = exports.getCommandOutputNotEmpty = exports.getCommandOutput = exports.supportedPackageManagers = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const exec = __importStar(__nccwpck_require__(1514));
 const cache = __importStar(__nccwpck_require__(7799));
@@ -60548,7 +60548,7 @@ const getProjectDirectoriesFromCacheDependencyPath = (cacheDependencyPath) => __
 const getCacheDirectoriesFromCacheDependencyPath = (packageManagerInfo, cacheDependencyPath) => __awaiter(void 0, void 0, void 0, function* () {
     const projectDirectories = yield getProjectDirectoriesFromCacheDependencyPath(cacheDependencyPath);
     const cacheFoldersPaths = yield Promise.all(projectDirectories.map((projectDirectory) => __awaiter(void 0, void 0, void 0, function* () {
-        const cacheFolderPath = packageManagerInfo.getCacheFolderPath(projectDirectory);
+        const cacheFolderPath = yield packageManagerInfo.getCacheFolderPath(projectDirectory);
         core.debug(`${packageManagerInfo.name}'s cache folder "${cacheFolderPath}" configured for the directory "${projectDirectory}"`);
         return cacheFolderPath;
     })));
@@ -60592,16 +60592,28 @@ exports.getCacheDirectories = getCacheDirectories;
  *  - if local cache is not explicitly enabled (not yarn3), return false
  *  - return true otherwise
  */
-const isCacheManagedByYarn3 = (directory) => __awaiter(void 0, void 0, void 0, function* () {
+const projectHasYarnBerryManagedDependencies = (directory) => __awaiter(void 0, void 0, void 0, function* () {
     const workDir = directory || process.env.GITHUB_WORKSPACE || '.';
+    core.debug(`check if "${workDir}" has locally managed yarn3 dependencies`);
     // if .yarn/cache directory exists the cache is managed by version control system
     const yarnCacheFile = path_1.default.join(workDir, '.yarn', 'cache');
-    if (fs_1.default.existsSync(yarnCacheFile) && fs_1.default.lstatSync(yarnCacheFile).isDirectory())
+    if (fs_1.default.existsSync(yarnCacheFile) &&
+        fs_1.default.lstatSync(yarnCacheFile).isDirectory()) {
+        core.debug(`"${workDir}" has .yarn/cache - dependencies are kept in the repository`);
         return Promise.resolve(false);
-    // NOTE: yarn1 returns 'undefined' with rc = 0
+    }
+    // NOTE: yarn1 returns 'undefined' with return code = 0
     const enableGlobalCache = yield exports.getCommandOutput('yarn config get enableGlobalCache', workDir);
     // only local cache is not managed by yarn
-    return enableGlobalCache === 'false';
+    const managed = enableGlobalCache.includes('false');
+    if (managed) {
+        core.debug(`"${workDir}" dependencies are managed by yarn 3 locally`);
+        return true;
+    }
+    else {
+        core.debug(`"${workDir}" dependencies are not managed by yarn 3 locally`);
+        return false;
+    }
 });
 /**
  * A function to report the repo contains Yarn managed projects
@@ -60610,16 +60622,16 @@ const isCacheManagedByYarn3 = (directory) => __awaiter(void 0, void 0, void 0, f
  *                              expected to be the result of `core.getInput('cache-dependency-path')`
  * @return - true if all project directories configured to be Yarn managed
  */
-const repoHasYarn3ManagedCache = (packageManagerInfo, cacheDependencyPath) => __awaiter(void 0, void 0, void 0, function* () {
+const repoHasYarnBerryManagedDependencies = (packageManagerInfo, cacheDependencyPath) => __awaiter(void 0, void 0, void 0, function* () {
     if (packageManagerInfo.name !== 'yarn')
         return false;
     const yarnDirs = cacheDependencyPath
         ? yield getProjectDirectoriesFromCacheDependencyPath(cacheDependencyPath)
         : [''];
-    const isManagedList = yield Promise.all(yarnDirs.map(isCacheManagedByYarn3));
+    const isManagedList = yield Promise.all(yarnDirs.map(projectHasYarnBerryManagedDependencies));
     return isManagedList.every(Boolean);
 });
-exports.repoHasYarn3ManagedCache = repoHasYarn3ManagedCache;
+exports.repoHasYarnBerryManagedDependencies = repoHasYarnBerryManagedDependencies;
 function isGhes() {
     const ghUrl = new URL(process.env['GITHUB_SERVER_URL'] || 'https://github.com');
     return ghUrl.hostname.toUpperCase() !== 'GITHUB.COM';

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -60604,23 +60604,20 @@ const isCacheManagedByYarn3 = (directory) => __awaiter(void 0, void 0, void 0, f
     return enableGlobalCache === 'false';
 });
 /**
- * A function to report either the repo contains at least one Yarn managed directory
+ * A function to report the repo contains Yarn managed projects
  * @param packageManagerInfo - used to make sure current package manager is yarn
- * @return - true if there's at least one Yarn managed directory in the repo
+ * @param cacheDependencyPath - either a single string or multiline string with possible glob patterns
+ *                              expected to be the result of `core.getInput('cache-dependency-path')`
+ * @return - true if all project directories configured to be Yarn managed
  */
-const repoHasYarn3ManagedCache = (packageManagerInfo) => __awaiter(void 0, void 0, void 0, function* () {
+const repoHasYarn3ManagedCache = (packageManagerInfo, cacheDependencyPath) => __awaiter(void 0, void 0, void 0, function* () {
     if (packageManagerInfo.name !== 'yarn')
         return false;
-    const cacheDependencyPath = core.getInput('cache-dependency-path');
     const yarnDirs = cacheDependencyPath
         ? yield getProjectDirectoriesFromCacheDependencyPath(cacheDependencyPath)
         : [''];
-    for (const dir of yarnDirs.length === 0 ? [''] : yarnDirs) {
-        if (yield isCacheManagedByYarn3(dir)) {
-            return true;
-        }
-    }
-    return false;
+    const isManagedList = yield Promise.all(yarnDirs.map(isCacheManagedByYarn3));
+    return isManagedList.every(Boolean);
 });
 exports.repoHasYarn3ManagedCache = repoHasYarn3ManagedCache;
 function isGhes() {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -71157,7 +71157,7 @@ const restoreCache = (packageManager, cacheDependencyPath) => __awaiter(void 0, 
     const primaryKey = `${keyPrefix}-${fileHash}`;
     core.debug(`primary key is ${primaryKey}`);
     core.saveState(constants_1.State.CachePrimaryKey, primaryKey);
-    const cacheKey = (yield cache_utils_1.repoHasYarn3ManagedCache(packageManagerInfo))
+    const cacheKey = (yield cache_utils_1.repoHasYarn3ManagedCache(packageManagerInfo, cacheDependencyPath))
         ? yield cache.restoreCache(cachePaths, primaryKey, [keyPrefix])
         : yield cache.restoreCache(cachePaths, primaryKey);
     core.setOutput('cache-hit', Boolean(cacheKey));
@@ -71390,23 +71390,20 @@ const isCacheManagedByYarn3 = (directory) => __awaiter(void 0, void 0, void 0, f
     return enableGlobalCache === 'false';
 });
 /**
- * A function to report either the repo contains at least one Yarn managed directory
+ * A function to report the repo contains Yarn managed projects
  * @param packageManagerInfo - used to make sure current package manager is yarn
- * @return - true if there's at least one Yarn managed directory in the repo
+ * @param cacheDependencyPath - either a single string or multiline string with possible glob patterns
+ *                              expected to be the result of `core.getInput('cache-dependency-path')`
+ * @return - true if all project directories configured to be Yarn managed
  */
-const repoHasYarn3ManagedCache = (packageManagerInfo) => __awaiter(void 0, void 0, void 0, function* () {
+const repoHasYarn3ManagedCache = (packageManagerInfo, cacheDependencyPath) => __awaiter(void 0, void 0, void 0, function* () {
     if (packageManagerInfo.name !== 'yarn')
         return false;
-    const cacheDependencyPath = core.getInput('cache-dependency-path');
     const yarnDirs = cacheDependencyPath
         ? yield getProjectDirectoriesFromCacheDependencyPath(cacheDependencyPath)
         : [''];
-    for (const dir of yarnDirs.length === 0 ? [''] : yarnDirs) {
-        if (yield isCacheManagedByYarn3(dir)) {
-            return true;
-        }
-    }
-    return false;
+    const isManagedList = yield Promise.all(yarnDirs.map(isCacheManagedByYarn3));
+    return isManagedList.every(Boolean);
 });
 exports.repoHasYarn3ManagedCache = repoHasYarn3ManagedCache;
 function isGhes() {

--- a/src/cache-restore.ts
+++ b/src/cache-restore.ts
@@ -44,7 +44,10 @@ export const restoreCache = async (
 
   core.saveState(State.CachePrimaryKey, primaryKey);
 
-  const cacheKey = (await repoHasYarn3ManagedCache(packageManagerInfo))
+  const cacheKey = (await repoHasYarn3ManagedCache(
+    packageManagerInfo,
+    cacheDependencyPath
+  ))
     ? await cache.restoreCache(cachePaths, primaryKey, [keyPrefix])
     : await cache.restoreCache(cachePaths, primaryKey);
 


### PR DESCRIPTION
**Description:**

Add a function `cache-utils.ts:repoHasYarn3ManagedCache` returns `true` if there's at least one project with yarn3 managed cache

Yarn3 managed cache enables safe use of the previous cache `cache.restoreCache(cachePaths, primaryKey, [keyPrefix])`
because obsolete dependences are removed by Yarn not letting cache to grow endlessly

**Related issue:**
https://github.com/actions/setup-node/issues/325

The PR initially contained Node version in the key but it was removed due to
https://github.com/actions/setup-node/issues/325#issuecomment-1378444559

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.