### PR TITLE
Azure DevOps Artifacts support for registry-url

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,8 @@ inputs:
     description: 'Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm.'
   cache-dependency-path:
     description: 'Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc. Supports wildcards or a list of file names for caching multiple dependencies.'
+  username:
+    description: 'Used to specify username/password authentication for NPM, used for Azure DevOps Artifacts and registries which expect a username and password.'
 # TODO: add input to control forcing to pull from cloud or dist. 
 #       escape valve for someone having issues or needing the absolute latest which isn't cached yet
 outputs:

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -71082,8 +71082,8 @@ function writeRegistryToFile(registryUrl, fileLocation, alwaysAuth, username) {
     // Remove http: or https: from front of registry.
     const registryPrefix = registryUrl.replace(/(^\w+:|^)/, '');
     if (username) {
-        newContents += registryPrefix + `:_username=${username}${os.EOL}`;
-        newContents += registryPrefix + `:_email=dummy value` + os.EOL;
+        newContents += registryPrefix + `:username=${username}${os.EOL}`;
+        newContents += registryPrefix + `:email=dummy value` + os.EOL;
     }
     const authString = username
         ? registryPrefix + ':_password=${NODE_AUTH_TOKEN}'

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -71083,7 +71083,7 @@ function writeRegistryToFile(registryUrl, fileLocation, alwaysAuth, username) {
     const registryPrefix = registryUrl.replace(/(^\w+:|^)/, '');
     if (username) {
         newContents += registryPrefix + `:_username=${username}${os.EOL}`;
-        newContents += registryPrefix + `:_email=dummy value`;
+        newContents += registryPrefix + `:_email=dummy value` + os.EOL;
     }
     const authString = username
         ? registryPrefix + ':_password=${NODE_AUTH_TOKEN}'

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/actions/setup-node.git"
+    "url": "git+https://github.com/rapid-platform/setup-node.git"
   },
   "keywords": [
     "actions",

--- a/src/authutil.ts
+++ b/src/authutil.ts
@@ -53,7 +53,7 @@ function writeRegistryToFile(
 
   if (username) {
     newContents += registryPrefix + `:_username=${username}${os.EOL}`;
-    newContents += registryPrefix + `:_email=dummy value`;
+    newContents += registryPrefix + `:_email=dummy value` + os.EOL;
   }
 
   const authString: string = username

--- a/src/authutil.ts
+++ b/src/authutil.ts
@@ -52,8 +52,8 @@ function writeRegistryToFile(
   const registryPrefix = registryUrl.replace(/(^\w+:|^)/, '');
 
   if (username) {
-    newContents += registryPrefix + `:_username=${username}${os.EOL}`;
-    newContents += registryPrefix + `:_email=dummy value` + os.EOL;
+    newContents += registryPrefix + `:username=${username}${os.EOL}`;
+    newContents += registryPrefix + `:email=dummy value` + os.EOL;
   }
 
   const authString: string = username

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,8 +55,9 @@ export async function run() {
 
     const registryUrl: string = core.getInput('registry-url');
     const alwaysAuth: string = core.getInput('always-auth');
+    const username: string | undefined = core.getInput('username');
     if (registryUrl) {
-      auth.configAuthentication(registryUrl, alwaysAuth);
+      auth.configAuthentication(registryUrl, alwaysAuth, username);
     }
 
     if (cache && isCacheFeatureAvailable()) {


### PR DESCRIPTION
**Description:**
actions/setup-node does not support Azure DevOps Artifacts even though DevOps is also a Microsoft product.  This is because `actions/setup-node` configures a temporary `.npmrc` file with an `_authToken` syntax, but AzureDevops requires npm's `:username`, ":_password", and ":email" syntax.

This patch adds support for Azure DevOps, and other registries by adding a `username` action input parameter.  When this is input is set, the .npmrc file will be written with a :username, :_password and :email instead of an :_authToken.

Fetching private scoped packages from Azure DevOps Artifacts is now supported and working with this patch.

**Related issue:**
N/A

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.