### PR TITLE
Update to node 18.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ steps:
 - uses: actions/checkout@v3
 - uses: actions/setup-node@v3
   with:
-    node-version: 16
+    node-version: 18
 - run: npm ci
 - run: npm test
 ```


### PR DESCRIPTION
NodeJS 18.x is now LTS so we should update the default in the readme to get more of this in the wild and less of node 16.x which is on npm 8.x.
