### PR TITLE
Fix armv7 cache issue

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -71656,7 +71656,7 @@ class BaseDistribution {
         return version;
     }
     findVersionInHostedToolCacheDirectory() {
-        return tc.find('node', this.nodeInfo.versionSpec, this.nodeInfo.arch);
+        return tc.find('node', this.nodeInfo.versionSpec, this.translateArchToDistUrl(this.nodeInfo.arch));
     }
     getNodeJsVersions() {
         return __awaiter(this, void 0, void 0, function* () {

--- a/src/distributions/base-distribution.ts
+++ b/src/distributions/base-distribution.ts
@@ -88,7 +88,11 @@ export default abstract class BaseDistribution {
   }
 
   protected findVersionInHostedToolCacheDirectory() {
-    return tc.find('node', this.nodeInfo.versionSpec, this.translateArchToDistUrl(this.nodeInfo.arch));
+    return tc.find(
+      'node',
+      this.nodeInfo.versionSpec,
+      this.translateArchToDistUrl(this.nodeInfo.arch)
+    );
   }
 
   protected async getNodeJsVersions(): Promise<INodeVersion[]> {

--- a/src/distributions/base-distribution.ts
+++ b/src/distributions/base-distribution.ts
@@ -88,7 +88,7 @@ export default abstract class BaseDistribution {
   }
 
   protected findVersionInHostedToolCacheDirectory() {
-    return tc.find('node', this.nodeInfo.versionSpec, this.nodeInfo.arch);
+    return tc.find('node', this.nodeInfo.versionSpec, this.translateArchToDistUrl(this.nodeInfo.arch));
   }
 
   protected async getNodeJsVersions(): Promise<INodeVersion[]> {


### PR DESCRIPTION
**Description:**
Closes #793, see the details in #793.

Before:
setup-node will try to find the cached Node.js in ./arm/, which is never existing. 

After this fix:
setup-node will try to find the cached Node.js in ./arm7vl/

**Related issue:**
#793

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.