### PR TITLE
Change passing logic for cache input

### DIFF
--- a/__tests__/cache-save.test.ts
+++ b/__tests__/cache-save.test.ts
@@ -92,6 +92,9 @@ describe('run', () => {
 
     it('Package manager is not valid, skip caching', async () => {
       inputs['cache'] = 'yarn3';
+      getStateSpy.mockImplementation(key =>
+        key === State.CachePackageManager ? inputs['cache'] : ''
+      );
 
       await run();
 
@@ -108,7 +111,9 @@ describe('run', () => {
     it('should not save cache for yarn1', async () => {
       inputs['cache'] = 'yarn';
       getStateSpy.mockImplementation(key =>
-        key === State.CachePrimaryKey || key === State.CacheMatchedKey
+        key === State.CachePackageManager
+          ? inputs['cache']
+          : key === State.CachePrimaryKey || key === State.CacheMatchedKey
           ? yarnFileHash
           : key === State.CachePaths
           ? '["/foo/bar"]'
@@ -117,8 +122,8 @@ describe('run', () => {
 
       await run();
 
-      expect(getInputSpy).toHaveBeenCalled();
-      expect(getStateSpy).toHaveBeenCalledTimes(3);
+      expect(getInputSpy).not.toHaveBeenCalled();
+      expect(getStateSpy).toHaveBeenCalledTimes(4);
       expect(getCommandOutputSpy).toHaveBeenCalledTimes(0);
       expect(debugSpy).toHaveBeenCalledTimes(0);
       expect(infoSpy).toHaveBeenCalledWith(
@@ -130,7 +135,9 @@ describe('run', () => {
     it('should not save cache for yarn2', async () => {
       inputs['cache'] = 'yarn';
       getStateSpy.mockImplementation(key =>
-        key === State.CachePrimaryKey || key === State.CacheMatchedKey
+        key === State.CachePackageManager
+          ? inputs['cache']
+          : key === State.CachePrimaryKey || key === State.CacheMatchedKey
           ? yarnFileHash
           : key === State.CachePaths
           ? '["/foo/bar"]'
@@ -139,8 +146,8 @@ describe('run', () => {
 
       await run();
 
-      expect(getInputSpy).toHaveBeenCalled();
-      expect(getStateSpy).toHaveBeenCalledTimes(3);
+      expect(getInputSpy).not.toHaveBeenCalled();
+      expect(getStateSpy).toHaveBeenCalledTimes(4);
       expect(getCommandOutputSpy).toHaveBeenCalledTimes(0);
       expect(debugSpy).toHaveBeenCalledTimes(0);
       expect(infoSpy).toHaveBeenCalledWith(
@@ -152,7 +159,9 @@ describe('run', () => {
     it('should not save cache for npm', async () => {
       inputs['cache'] = 'npm';
       getStateSpy.mockImplementation(key =>
-        key === State.CachePrimaryKey || key === State.CacheMatchedKey
+        key === State.CachePackageManager
+          ? inputs['cache']
+          : key === State.CachePrimaryKey || key === State.CacheMatchedKey
           ? yarnFileHash
           : key === State.CachePaths
           ? '["/foo/bar"]'
@@ -162,8 +171,8 @@ describe('run', () => {
 
       await run();
 
-      expect(getInputSpy).toHaveBeenCalled();
-      expect(getStateSpy).toHaveBeenCalledTimes(3);
+      expect(getInputSpy).not.toHaveBeenCalled();
+      expect(getStateSpy).toHaveBeenCalledTimes(4);
       expect(getCommandOutputSpy).toHaveBeenCalledTimes(0);
       expect(debugSpy).toHaveBeenCalledTimes(0);
       expect(setFailedSpy).not.toHaveBeenCalled();
@@ -172,7 +181,9 @@ describe('run', () => {
     it('should not save cache for pnpm', async () => {
       inputs['cache'] = 'pnpm';
       getStateSpy.mockImplementation(key =>
-        key === State.CachePrimaryKey || key === State.CacheMatchedKey
+        key === State.CachePackageManager
+          ? inputs['cache']
+          : key === State.CachePrimaryKey || key === State.CacheMatchedKey
           ? yarnFileHash
           : key === State.CachePaths
           ? '["/foo/bar"]'
@@ -181,8 +192,8 @@ describe('run', () => {
 
       await run();
 
-      expect(getInputSpy).toHaveBeenCalled();
-      expect(getStateSpy).toHaveBeenCalledTimes(3);
+      expect(getInputSpy).not.toHaveBeenCalled();
+      expect(getStateSpy).toHaveBeenCalledTimes(4);
       expect(getCommandOutputSpy).toHaveBeenCalledTimes(0);
       expect(debugSpy).toHaveBeenCalledTimes(0);
       expect(setFailedSpy).not.toHaveBeenCalled();
@@ -193,7 +204,9 @@ describe('run', () => {
     it('saves cache from yarn 1', async () => {
       inputs['cache'] = 'yarn';
       getStateSpy.mockImplementation((key: string) =>
-        key === State.CacheMatchedKey
+        key === State.CachePackageManager
+          ? inputs['cache']
+          : key === State.CacheMatchedKey
           ? yarnFileHash
           : key === State.CachePrimaryKey
           ? npmFileHash
@@ -204,8 +217,8 @@ describe('run', () => {
 
       await run();
 
-      expect(getInputSpy).toHaveBeenCalled();
-      expect(getStateSpy).toHaveBeenCalledTimes(3);
+      expect(getInputSpy).not.toHaveBeenCalled();
+      expect(getStateSpy).toHaveBeenCalledTimes(4);
       expect(getCommandOutputSpy).toHaveBeenCalledTimes(0);
       expect(debugSpy).toHaveBeenCalledTimes(0);
       expect(infoSpy).not.toHaveBeenCalledWith(
@@ -221,7 +234,9 @@ describe('run', () => {
     it('saves cache from yarn 2', async () => {
       inputs['cache'] = 'yarn';
       getStateSpy.mockImplementation((key: string) =>
-        key === State.CacheMatchedKey
+        key === State.CachePackageManager
+          ? inputs['cache']
+          : key === State.CacheMatchedKey
           ? yarnFileHash
           : key === State.CachePrimaryKey
           ? npmFileHash
@@ -232,8 +247,8 @@ describe('run', () => {
 
       await run();
 
-      expect(getInputSpy).toHaveBeenCalled();
-      expect(getStateSpy).toHaveBeenCalledTimes(3);
+      expect(getInputSpy).not.toHaveBeenCalled();
+      expect(getStateSpy).toHaveBeenCalledTimes(4);
       expect(getCommandOutputSpy).toHaveBeenCalledTimes(0);
       expect(debugSpy).toHaveBeenCalledTimes(0);
       expect(infoSpy).not.toHaveBeenCalledWith(
@@ -249,7 +264,9 @@ describe('run', () => {
     it('saves cache from npm', async () => {
       inputs['cache'] = 'npm';
       getStateSpy.mockImplementation((key: string) =>
-        key === State.CacheMatchedKey
+        key === State.CachePackageManager
+          ? inputs['cache']
+          : key === State.CacheMatchedKey
           ? npmFileHash
           : key === State.CachePrimaryKey
           ? yarnFileHash
@@ -260,8 +277,8 @@ describe('run', () => {
 
       await run();
 
-      expect(getInputSpy).toHaveBeenCalled();
-      expect(getStateSpy).toHaveBeenCalledTimes(3);
+      expect(getInputSpy).not.toHaveBeenCalled();
+      expect(getStateSpy).toHaveBeenCalledTimes(4);
       expect(getCommandOutputSpy).toHaveBeenCalledTimes(0);
       expect(debugSpy).toHaveBeenCalledTimes(0);
       expect(infoSpy).not.toHaveBeenCalledWith(
@@ -277,7 +294,9 @@ describe('run', () => {
     it('saves cache from pnpm', async () => {
       inputs['cache'] = 'pnpm';
       getStateSpy.mockImplementation((key: string) =>
-        key === State.CacheMatchedKey
+        key === State.CachePackageManager
+          ? inputs['cache']
+          : key === State.CacheMatchedKey
           ? pnpmFileHash
           : key === State.CachePrimaryKey
           ? npmFileHash
@@ -288,8 +307,8 @@ describe('run', () => {
 
       await run();
 
-      expect(getInputSpy).toHaveBeenCalled();
-      expect(getStateSpy).toHaveBeenCalledTimes(3);
+      expect(getInputSpy).not.toHaveBeenCalled();
+      expect(getStateSpy).toHaveBeenCalledTimes(4);
       expect(getCommandOutputSpy).toHaveBeenCalledTimes(0);
       expect(debugSpy).toHaveBeenCalledTimes(0);
       expect(infoSpy).not.toHaveBeenCalledWith(
@@ -305,7 +324,9 @@ describe('run', () => {
     it('save with -1 cacheId , should not fail workflow', async () => {
       inputs['cache'] = 'npm';
       getStateSpy.mockImplementation((key: string) =>
-        key === State.CacheMatchedKey
+        key === State.CachePackageManager
+          ? inputs['cache']
+          : key === State.CacheMatchedKey
           ? npmFileHash
           : key === State.CachePrimaryKey
           ? yarnFileHash
@@ -319,8 +340,8 @@ describe('run', () => {
 
       await run();
 
-      expect(getInputSpy).toHaveBeenCalled();
-      expect(getStateSpy).toHaveBeenCalledTimes(3);
+      expect(getInputSpy).not.toHaveBeenCalled();
+      expect(getStateSpy).toHaveBeenCalledTimes(4);
       expect(getCommandOutputSpy).toHaveBeenCalledTimes(0);
       expect(debugSpy).toHaveBeenCalledTimes(0);
       expect(infoSpy).not.toHaveBeenCalledWith(
@@ -336,7 +357,9 @@ describe('run', () => {
     it('saves with error from toolkit, should fail workflow', async () => {
       inputs['cache'] = 'npm';
       getStateSpy.mockImplementation((key: string) =>
-        key === State.CacheMatchedKey
+        key === State.CachePackageManager
+          ? inputs['cache']
+          : key === State.CacheMatchedKey
           ? npmFileHash
           : key === State.CachePrimaryKey
           ? yarnFileHash
@@ -350,8 +373,8 @@ describe('run', () => {
 
       await run();
 
-      expect(getInputSpy).toHaveBeenCalled();
-      expect(getStateSpy).toHaveBeenCalledTimes(3);
+      expect(getInputSpy).not.toHaveBeenCalled();
+      expect(getStateSpy).toHaveBeenCalledTimes(4);
       expect(getCommandOutputSpy).toHaveBeenCalledTimes(0);
       expect(debugSpy).toHaveBeenCalledTimes(0);
       expect(infoSpy).not.toHaveBeenCalledWith(

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -60381,7 +60381,7 @@ process.on('uncaughtException', e => {
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const cacheLock = core.getInput('cache');
+            const cacheLock = core.getState(constants_1.State.CachePackageManager);
             yield cachePackages(cacheLock);
         }
         catch (error) {
@@ -60692,6 +60692,7 @@ var LockType;
 })(LockType = exports.LockType || (exports.LockType = {}));
 var State;
 (function (State) {
+    State["CachePackageManager"] = "SETUP_NODE_CACHE_PACKAGE_MANAGER";
     State["CachePrimaryKey"] = "CACHE_KEY";
     State["CacheMatchedKey"] = "CACHE_RESULT";
     State["CachePaths"] = "CACHE_PATHS";

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -71479,6 +71479,7 @@ var LockType;
 })(LockType = exports.LockType || (exports.LockType = {}));
 var State;
 (function (State) {
+    State["CachePackageManager"] = "SETUP_NODE_CACHE_PACKAGE_MANAGER";
     State["CachePrimaryKey"] = "CACHE_KEY";
     State["CacheMatchedKey"] = "CACHE_RESULT";
     State["CachePaths"] = "CACHE_PATHS";
@@ -72209,6 +72210,7 @@ const cache_restore_1 = __nccwpck_require__(9517);
 const cache_utils_1 = __nccwpck_require__(1678);
 const installer_factory_1 = __nccwpck_require__(5617);
 const util_1 = __nccwpck_require__(2629);
+const constants_1 = __nccwpck_require__(9042);
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -72249,6 +72251,7 @@ function run() {
                 auth.configAuthentication(registryUrl, alwaysAuth);
             }
             if (cache && cache_utils_1.isCacheFeatureAvailable()) {
+                core.saveState(constants_1.State.CachePackageManager, cache);
                 const cacheDependencyPath = core.getInput('cache-dependency-path');
                 yield cache_restore_1.restoreCache(cache, cacheDependencyPath);
             }

--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -16,7 +16,7 @@ process.on('uncaughtException', e => {
 
 export async function run() {
   try {
-    const cacheLock = core.getInput('cache');
+    const cacheLock = core.getState(State.CachePackageManager);
     await cachePackages(cacheLock);
   } catch (error) {
     core.setFailed(error.message);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ export enum LockType {
 }
 
 export enum State {
+  CachePackageManager = 'SETUP_NODE_CACHE_PACKAGE_MANAGER',
   CachePrimaryKey = 'CACHE_KEY',
   CacheMatchedKey = 'CACHE_RESULT',
   CachePaths = 'CACHE_PATHS'

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import {restoreCache} from './cache-restore';
 import {isCacheFeatureAvailable} from './cache-utils';
 import {getNodejsDistribution} from './distributions/installer-factory';
 import {parseNodeVersionFile, printEnvDetailsAndSetOutput} from './util';
+import {State} from './constants';
 
 export async function run() {
   try {
@@ -60,6 +61,7 @@ export async function run() {
     }
 
     if (cache && isCacheFeatureAvailable()) {
+      core.saveState(State.CachePackageManager, cache);
       const cacheDependencyPath = core.getInput('cache-dependency-path');
       await restoreCache(cache, cacheDependencyPath);
     }


### PR DESCRIPTION
**Description:**
In scope of this pull request we change logic to pass cache input to post step through get state because it can during the post step in [composite action the boolean value](https://github.com/actions/runner/issues/2238) can change and by condition give the different result for getInput
**Related issue:**
https://github.com/actions/setup-node/issues/814
https://github.com/actions/setup-node/issues/797

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.