### PR TITLE
Remove filter for cached paths

### DIFF
--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -60361,14 +60361,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.run = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const cache = __importStar(__nccwpck_require__(7799));
-const fs_1 = __importDefault(__nccwpck_require__(7147));
 const constants_1 = __nccwpck_require__(9042);
 const cache_utils_1 = __nccwpck_require__(1678);
 // Catch and log any unhandled exceptions.  These exceptions can leak out of the uploadChunk method in
@@ -60393,8 +60389,7 @@ exports.run = run;
 const cachePackages = (packageManager) => __awaiter(void 0, void 0, void 0, function* () {
     const state = core.getState(constants_1.State.CacheMatchedKey);
     const primaryKey = core.getState(constants_1.State.CachePrimaryKey);
-    let cachePaths = JSON.parse(core.getState(constants_1.State.CachePaths) || '[]');
-    cachePaths = cachePaths.filter(fs_1.default.existsSync);
+    const cachePaths = JSON.parse(core.getState(constants_1.State.CachePaths) || '[]');
     const packageManagerInfo = yield cache_utils_1.getPackageManagerInfo(packageManager);
     if (!packageManagerInfo) {
         core.debug(`Caching for '${packageManager}' is not supported`);

--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -1,8 +1,6 @@
 import * as core from '@actions/core';
 import * as cache from '@actions/cache';
 
-import fs from 'fs';
-
 import {State} from './constants';
 import {getPackageManagerInfo} from './cache-utils';
 

--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -26,10 +26,9 @@ export async function run() {
 const cachePackages = async (packageManager: string) => {
   const state = core.getState(State.CacheMatchedKey);
   const primaryKey = core.getState(State.CachePrimaryKey);
-  let cachePaths = JSON.parse(
+  const cachePaths = JSON.parse(
     core.getState(State.CachePaths) || '[]'
   ) as string[];
-  cachePaths = cachePaths.filter(fs.existsSync);
 
   const packageManagerInfo = await getPackageManagerInfo(packageManager);
   if (!packageManagerInfo) {


### PR DESCRIPTION
**Description:**
In scope of this pull request we remove filter for cached paths because it is done in `toolkit/cache` with globber. 

**Related issue:**

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.