### PR TITLE
feat: add input to only restore cache without saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ See [action.yml](action.yml)
     # Default: ''
     cache-dependency-path: ''
 
+    # Set this option if you dont want the action to save the cache if it couldnt be restored
+    # Default: false
+    cache-restore-only: ''
+
     # Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, 
     # and set up auth to read in from env.NODE_AUTH_TOKEN.
     # Default: ''

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
     description: 'Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm.'
   cache-dependency-path:
     description: 'Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc. Supports wildcards or a list of file names for caching multiple dependencies.'
+  cache-restore-only:
+    description: 'Set this option if you dont want to save the cache when it couldnt be restored.'
+    default: false
 # TODO: add input to control forcing to pull from cloud or dist.
 #       escape valve for someone having issues or needing the absolute latest which isn't cached yet
 outputs:

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -60396,7 +60396,7 @@ const cachePackages = (packageManager) => __awaiter(void 0, void 0, void 0, func
         return;
     }
     if (core.getInput('cache-restore-only') == 'true') {
-        core.info(`Cache was not saved since 'cache-restore-only' was set to true}`);
+        core.info(`Cache was not saved since 'cache-restore-only' was set to true`);
         return;
     }
     if (!cachePaths.length) {

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -60395,6 +60395,10 @@ const cachePackages = (packageManager) => __awaiter(void 0, void 0, void 0, func
         core.debug(`Caching for '${packageManager}' is not supported`);
         return;
     }
+    if (core.getInput('cache-restore-only') == 'true') {
+        core.info(`Cache was not saved since 'cache-restore-only' was set to true}`);
+        return;
+    }
     if (!cachePaths.length) {
         // TODO: core.getInput has a bug - it can return undefined despite its definition (tests only?)
         //       export declare function getInput(name: string, options?: InputOptions): string;

--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -33,6 +33,10 @@ const cachePackages = async (packageManager: string) => {
     core.debug(`Caching for '${packageManager}' is not supported`);
     return;
   }
+  if (core.getInput('cache-restore-only') == true ){
+    core.info(`Cache was not saved since 'cache-restore-only' was set }`);
+    return;
+  }
 
   if (!cachePaths.length) {
     // TODO: core.getInput has a bug - it can return undefined despite its definition (tests only?)

--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -34,9 +34,7 @@ const cachePackages = async (packageManager: string) => {
     return;
   }
   if (core.getInput('cache-restore-only') == 'true') {
-    core.info(
-      `Cache was not saved since 'cache-restore-only' was set to true}`
-    );
+    core.info(`Cache was not saved since 'cache-restore-only' was set to true`);
     return;
   }
 

--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -33,8 +33,10 @@ const cachePackages = async (packageManager: string) => {
     core.debug(`Caching for '${packageManager}' is not supported`);
     return;
   }
-  if (core.getInput('cache-restore-only') == true ){
-    core.info(`Cache was not saved since 'cache-restore-only' was set }`);
+  if (core.getInput('cache-restore-only') == 'true') {
+    core.info(
+      `Cache was not saved since 'cache-restore-only' was set to true}`
+    );
     return;
   }
 


### PR DESCRIPTION
**Description:**
Adds a new input "cache-restore-only" to disable saving the cache in cases where it wasn't restored.
**Related issue:**
https://github.com/actions/setup-node/issues/663

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.