### PR TITLE
feat: bump to use node20 runtime, actions/checkout to v4

### DIFF
--- a/.github/workflows/e2e-cache.yml
+++ b/.github/workflows/e2e-cache.yml
@@ -21,7 +21,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [12, 14, 16]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Clean global cache
         run: npm cache clean --force
       - name: Setup Node
@@ -44,7 +44,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [12, 14, 16]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
@@ -77,7 +77,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [14, 16]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Yarn version
         run: yarn --version
       - name: Generate yarn file
@@ -109,7 +109,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [12, 14, 16]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Update yarn
         run: yarn set version berry
       - name: Yarn version
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: prepare sub-projects
         run: __tests__/prepare-yarn-subprojects.sh yarn1
@@ -170,7 +170,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: prepare sub-projects
         run: __tests__/prepare-yarn-subprojects.sh keepcache keepcache
@@ -197,7 +197,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: prepare sub-projects
         run: __tests__/prepare-yarn-subprojects.sh global
@@ -224,7 +224,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: prepare sub-projects
         run: /bin/bash __tests__/prepare-yarn-subprojects.sh keepcache

--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -25,7 +25,7 @@ jobs:
     env:
       https_proxy: http://squid-proxy:3128
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Clear tool cache
         run: rm -rf $RUNNER_TOOL_CACHE/*
       - name: Setup node 14
@@ -41,7 +41,7 @@ jobs:
       https_proxy: http://no-such-proxy:3128
       no_proxy: api.github.com,github.com,nodejs.org,registry.npmjs.org,*.s3.amazonaws.com,s3.amazonaws.com
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Clear tool cache
         run: rm -rf $RUNNER_TOOL_CACHE/*
       - name: Setup node 11

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [10, 12, 14]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node
         uses: ./
         with:
@@ -37,7 +37,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [lts/dubnium, lts/erbium, lts/fermium, lts/*, lts/-1]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node
         uses: ./
         with:
@@ -64,7 +64,7 @@ jobs:
             '20.0.0-v8-canary20221101e50e45c9f8'
           ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node
         uses: ./
         with:
@@ -85,7 +85,7 @@ jobs:
         node-version:
           [16.0.0-nightly20210420a0261d231c, 17-nightly, 18.0.0-nightly]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node
         uses: ./
         with:
@@ -105,7 +105,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [16.0.0-rc.1, 18.0.0-rc.2, 19.0.0-rc.0]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node
         uses: ./
         with:
@@ -125,7 +125,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [10.15, 12.16.0, 14.2.0, 16.3.0]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node
         uses: ./
         with:
@@ -142,7 +142,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [10, 12, 14]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node and check latest
         uses: ./
         with:
@@ -161,7 +161,7 @@ jobs:
         node-version-file:
           [.nvmrc, .tool-versions, .tool-versions-node, package.json]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Remove volta from package.json
         shell: bash
         run: cat <<< "$(jq 'del(.volta)' ./__tests__/data/package.json)" > ./__tests__/data/package.json
@@ -179,7 +179,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup node from node version file
         uses: ./
         with:
@@ -195,7 +195,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [11, 13]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node from dist
         uses: ./
         with:
@@ -211,7 +211,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # test old versions which didn't have npm and layout different
       - name: Setup node 0.12.18 from dist
         uses: ./
@@ -224,7 +224,7 @@ jobs:
   arch:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup node 14 x86 from dist
         uses: ./
         with:
@@ -248,7 +248,7 @@ jobs:
           echo "LATEST_NODE_VERSION=$latestNodeVersion" >> $GITHUB_OUTPUT
         id: version
         shell: bash
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node
         uses: ./
         with:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ See [action.yml](action.yml)
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-node@v3
   with:
     node-version: 18
@@ -132,7 +132,7 @@ See the examples of using cache for `yarn`/`pnpm` and `cache-dependency-path` in
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-node@v3
   with:
     node-version: 16
@@ -145,7 +145,7 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-node@v3
   with:
     node-version: 16
@@ -166,7 +166,7 @@ jobs:
         node: [ 14, 16, 18 ]
     name: Node ${{ matrix.node }} sample
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup node
         uses: actions/setup-node@v3
         with:

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ outputs:
   node-version:
     description: 'The installed node version.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/setup/index.js'
   post: 'dist/cache-save/index.js'
   post-if: success()

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -45,7 +45,7 @@ If `check-latest` is set to `true`, the action first checks if the cached versio
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-node@v3
   with:
     node-version: '16'
@@ -63,7 +63,7 @@ See [supported version syntax](https://github.com/actions/setup-node#supported-v
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-node@v3
   with:
     node-version-file: '.nvmrc'
@@ -95,7 +95,7 @@ jobs:
     runs-on: windows-latest
     name: Node sample
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: '14'
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Node sample
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: '20.0.0-v8-canary' # it will install the latest v8 canary release for node 20.0.0
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Node sample
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: '20-v8-canary' # it will install the latest v8 canary release for node 20
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Node sample
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 'v20.1.1-v8-canary20221103f7e2421e91'
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Node sample
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: '16-nightly' # it will install the latest nightly release for node 16
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Node sample
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: '16.0.0-nightly' # it will install the latest nightly release for node 16.0.0
@@ -199,7 +199,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Node sample
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: '16.0.0-nightly20210420a0261d231c'
@@ -217,7 +217,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Node sample
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: '16.0.0-rc.1'
@@ -234,7 +234,7 @@ The action follows [actions/cache](https://github.com/actions/cache/blob/main/ex
 Yarn caching handles both yarn versions: 1 or 2.
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-node@v3
   with:
     node-version: '14'
@@ -253,7 +253,7 @@ steps:
 # NOTE: pnpm caching support requires pnpm version >= 6.10.0
 
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: pnpm/action-setup@v2
   with:
     version: 6.32.9
@@ -272,7 +272,7 @@ steps:
 **Using wildcard patterns to cache dependencies**
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-node@v3
   with:
     node-version: '14'
@@ -285,7 +285,7 @@ steps:
 **Using a list of file paths to cache dependencies**
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-node@v3
   with:
     node-version: '14'
@@ -322,7 +322,7 @@ jobs:
             architecture: x86
     name: Node ${{ matrix.node_version }} - ${{ matrix.architecture }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup node
         uses: actions/setup-node@v3
         with:
@@ -335,7 +335,7 @@ jobs:
 ## Publish to npmjs and GPR with npm
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-node@v3
   with:
     node-version: '14.x'
@@ -355,7 +355,7 @@ steps:
 ## Publish to npmjs and GPR with yarn
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-node@v3
   with:
     node-version: '14.x'
@@ -375,7 +375,7 @@ steps:
 ## Use private packages
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-node@v3
   with:
     node-version: '14.x'
@@ -395,7 +395,7 @@ Below you can find a sample "Setup .yarnrc.yml" step, that is going to allow you
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-node@v3
   with:
     node-version: '14.x'

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -45,7 +45,7 @@ If `check-latest` is set to `true`, the action first checks if the cached versio
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v3
 - uses: actions/setup-node@v3
   with:
     node-version: '16'
@@ -63,7 +63,7 @@ See [supported version syntax](https://github.com/actions/setup-node#supported-v
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v3
 - uses: actions/setup-node@v3
   with:
     node-version-file: '.nvmrc'
@@ -95,7 +95,7 @@ jobs:
     runs-on: windows-latest
     name: Node sample
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: '14'
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Node sample
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: '20.0.0-v8-canary' # it will install the latest v8 canary release for node 20.0.0
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Node sample
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: '20-v8-canary' # it will install the latest v8 canary release for node 20
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Node sample
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 'v20.1.1-v8-canary20221103f7e2421e91'
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Node sample
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: '16-nightly' # it will install the latest nightly release for node 16
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Node sample
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: '16.0.0-nightly' # it will install the latest nightly release for node 16.0.0
@@ -199,7 +199,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Node sample
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: '16.0.0-nightly20210420a0261d231c'
@@ -217,7 +217,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Node sample
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: '16.0.0-rc.1'
@@ -234,7 +234,7 @@ The action follows [actions/cache](https://github.com/actions/cache/blob/main/ex
 Yarn caching handles both yarn versions: 1 or 2.
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v3
 - uses: actions/setup-node@v3
   with:
     node-version: '14'
@@ -253,7 +253,7 @@ steps:
 # NOTE: pnpm caching support requires pnpm version >= 6.10.0
 
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v3
 - uses: pnpm/action-setup@v2
   with:
     version: 6.32.9
@@ -272,7 +272,7 @@ steps:
 **Using wildcard patterns to cache dependencies**
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v3
 - uses: actions/setup-node@v3
   with:
     node-version: '14'
@@ -285,7 +285,7 @@ steps:
 **Using a list of file paths to cache dependencies**
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v3
 - uses: actions/setup-node@v3
   with:
     node-version: '14'
@@ -322,7 +322,7 @@ jobs:
             architecture: x86
     name: Node ${{ matrix.node_version }} - ${{ matrix.architecture }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Setup node
         uses: actions/setup-node@v3
         with:
@@ -335,7 +335,7 @@ jobs:
 ## Publish to npmjs and GPR with npm
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v3
 - uses: actions/setup-node@v3
   with:
     node-version: '14.x'
@@ -355,7 +355,7 @@ steps:
 ## Publish to npmjs and GPR with yarn
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v3
 - uses: actions/setup-node@v3
   with:
     node-version: '14.x'
@@ -375,7 +375,7 @@ steps:
 ## Use private packages
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v3
 - uses: actions/setup-node@v3
   with:
     node-version: '14.x'
@@ -395,7 +395,7 @@ Below you can find a sample "Setup .yarnrc.yml" step, that is going to allow you
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v3
 - uses: actions/setup-node@v3
   with:
     node-version: '14.x'


### PR DESCRIPTION
**Description:**

Node20 was added to Actions Runner on v2.308.0 and Node16 reaches end of life soon on 11 Sep 2023.

Therefore, This PR updates the default runtime to node20. I have bumped the actions/checkout version to v4 for the same.

**Related issue:**

https://github.com/actions/runner/pull/2732


**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.

-----------------
A major version bump might be needed after the PRs merge.