### PR TITLE
Fix node-version-file interprets entire package.json as a version

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -101,6 +101,7 @@ describe('main tests', () => {
       ${'  14.1.0  '}                              | ${'14.1.0'}
       ${'{"volta": {"node": ">=14.0.0 <=17.0.0"}}'}| ${'>=14.0.0 <=17.0.0'}
       ${'{"engines": {"node": "17.0.0"}}'}         | ${'17.0.0'}
+      ${'{}'}                                      | ${null}
     `.it('parses "$contents"', ({contents, expected}) => {
       expect(util.parseNodeVersionFile(contents)).toBe(expected);
     });

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -83329,9 +83329,25 @@ function parseNodeVersionFile(contents) {
     let nodeVersion;
     // Try parsing the file as an NPM `package.json` file.
     try {
-        nodeVersion = (_a = JSON.parse(contents).volta) === null || _a === void 0 ? void 0 : _a.node;
-        if (!nodeVersion)
-            nodeVersion = (_b = JSON.parse(contents).engines) === null || _b === void 0 ? void 0 : _b.node;
+        const manifest = JSON.parse(contents);
+        // JSON can parse numbers, but that's handled later
+        if (typeof manifest === 'object') {
+            nodeVersion = (_a = manifest.volta) === null || _a === void 0 ? void 0 : _a.node;
+            if (!nodeVersion)
+                nodeVersion = (_b = manifest.engines) === null || _b === void 0 ? void 0 : _b.node;
+            // if contents are an object, we parsed JSON
+            // this can happen if node-version-file is a package.json
+            // yet contains no volta.node or engines.node
+            //
+            // if node-version file is _not_ json, control flow
+            // will not have reached these lines.
+            //
+            // And because we've reached here, we know the contents
+            // *are* JSON, so no further string parsing makes sense.
+            if (!nodeVersion) {
+                return null;
+            }
+        }
     }
     catch (_d) {
         core.info('Node version file is not JSON file');

--- a/src/main.ts
+++ b/src/main.ts
@@ -105,7 +105,17 @@ function resolveVersionInput(): string {
       );
     }
 
-    version = parseNodeVersionFile(fs.readFileSync(versionFilePath, 'utf8'));
+    const parsedVersion = parseNodeVersionFile(
+      fs.readFileSync(versionFilePath, 'utf8')
+    );
+
+    if (parsedVersion) {
+      version = parsedVersion;
+    } else {
+      core.warning(
+        `Could not determine node version from ${versionFilePath}. Falling back`
+      );
+    }
 
     core.info(`Resolved ${versionFileInput} as ${version}`);
   }


### PR DESCRIPTION
**Description:**
Resolves an issue where json files were used as node-versions

After building the action on another branch:
Here is a demonstration of the change working: https://github.com/NullVoxPopuli/actions-testing/actions/runs/6411088958/job/17405783026#step:4:11
And previously not working: https://github.com/NullVoxPopuli/actions-testing/actions/runs/6411088958/job/17405783212#step:4:11 (as described in issue #864) 

**Related issue:**
https://github.com/actions/setup-node/issues/864

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.