### PR TITLE
upgrade actions/checkout to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ See [action.yml](action.yml)
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-node@v3
   with:
     node-version: 18
@@ -132,7 +132,7 @@ See the examples of using cache for `yarn`/`pnpm` and `cache-dependency-path` in
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-node@v3
   with:
     node-version: 16
@@ -145,7 +145,7 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-node@v3
   with:
     node-version: 16
@@ -166,7 +166,7 @@ jobs:
         node: [ 14, 16, 18 ]
     name: Node ${{ matrix.node }} sample
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
**Description:**
Hi,

Thanks for your work. The `checkout` action has been [released to v4](https://github.com/actions/checkout/releases/tag/v4.0.0) a few weeks ago, I have updated the example to use it.

**Related issue:**
None

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.