### PR TITLE
Add notice about binaries not being updated yet

### DIFF
--- a/__tests__/official-installer.test.ts
+++ b/__tests__/official-installer.test.ts
@@ -357,6 +357,41 @@ describe('setup-node', () => {
     expect(cnSpy).toHaveBeenCalledWith(`::error::${errMsg}${osm.EOL}`);
   });
 
+  it('reports when download failed but version exists', async () => {
+    os.platform = 'linux';
+    os.arch = 'x64';
+
+    // a version which is not in the manifest but is in node dist
+    const versionSpec = '11.15.0';
+
+    inputs['node-version'] = versionSpec;
+    inputs['always-auth'] = false;
+    inputs['token'] = 'faketoken';
+
+    // ... but not in the local cache
+    findSpy.mockImplementation(() => '');
+
+    dlSpy.mockImplementationOnce(async () => {
+      throw new tc.HTTPError(404);
+    });
+
+    await main.run();
+
+    expect(getManifestSpy).toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      `Attempting to download ${versionSpec}...`
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      'Not found in manifest. Falling back to download directly from Node'
+    );
+    expect(dlSpy).toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      `Node version ${versionSpec} for platform ${os.platform} and architecture ${os.arch} was found but failed to download. ` +
+        'This usually happens when downloadable binaries are not fully updated at https://nodejs.org/. ' +
+        'To resolve this issue you may either fall back to the older version or try again later.'
+    );
+  });
+
   it('acquires specified architecture of node', async () => {
     for (const {arch, version, osSpec} of [
       {arch: 'x86', version: '12.16.2', osSpec: 'win32'},

--- a/__tests__/official-installer.test.ts
+++ b/__tests__/official-installer.test.ts
@@ -385,7 +385,7 @@ describe('setup-node', () => {
       'Not found in manifest. Falling back to download directly from Node'
     );
     expect(dlSpy).toHaveBeenCalled();
-    expect(logSpy).toHaveBeenCalledWith(
+    expect(warningSpy).toHaveBeenCalledWith(
       `Node version ${versionSpec} for platform ${os.platform} and architecture ${os.arch} was found but failed to download. ` +
         'This usually happens when downloadable binaries are not fully updated at https://nodejs.org/. ' +
         'To resolve this issue you may either fall back to the older version or try again later.'

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -72843,7 +72843,7 @@ class OfficialBuilds extends base_distribution_1.default {
             }
             catch (error) {
                 if (error instanceof tc.HTTPError && error.httpStatusCode === 404) {
-                    core.info(`Node version ${this.nodeInfo.versionSpec} for platform ${this.osPlat} and architecture ${this.nodeInfo.arch} was found but failed to download. ` +
+                    core.warning(`Node version ${this.nodeInfo.versionSpec} for platform ${this.osPlat} and architecture ${this.nodeInfo.arch} was found but failed to download. ` +
                         'This usually happens when downloadable binaries are not fully updated at https://nodejs.org/. ' +
                         'To resolve this issue you may either fall back to the older version or try again later.');
                 }

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -72783,50 +72783,72 @@ class OfficialBuilds extends base_distribution_1.default {
             let toolPath = this.findVersionInHostedToolCacheDirectory();
             if (toolPath) {
                 core.info(`Found in cache @ ${toolPath}`);
+                this.addToolPath(toolPath);
+                return;
             }
-            else {
-                let downloadPath = '';
-                try {
-                    core.info(`Attempting to download ${this.nodeInfo.versionSpec}...`);
-                    const versionInfo = yield this.getInfoFromManifest(this.nodeInfo.versionSpec, this.nodeInfo.stable, osArch, manifest);
-                    if (versionInfo) {
-                        core.info(`Acquiring ${versionInfo.resolvedVersion} - ${versionInfo.arch} from ${versionInfo.downloadUrl}`);
-                        downloadPath = yield tc.downloadTool(versionInfo.downloadUrl, undefined, this.nodeInfo.auth);
-                        if (downloadPath) {
-                            toolPath = yield this.extractArchive(downloadPath, versionInfo);
-                        }
-                    }
-                    else {
-                        core.info('Not found in manifest. Falling back to download directly from Node');
+            let downloadPath = '';
+            try {
+                core.info(`Attempting to download ${this.nodeInfo.versionSpec}...`);
+                const versionInfo = yield this.getInfoFromManifest(this.nodeInfo.versionSpec, this.nodeInfo.stable, osArch, manifest);
+                if (versionInfo) {
+                    core.info(`Acquiring ${versionInfo.resolvedVersion} - ${versionInfo.arch} from ${versionInfo.downloadUrl}`);
+                    downloadPath = yield tc.downloadTool(versionInfo.downloadUrl, undefined, this.nodeInfo.auth);
+                    if (downloadPath) {
+                        toolPath = yield this.extractArchive(downloadPath, versionInfo);
                     }
                 }
-                catch (err) {
-                    // Rate limit?
-                    if (err instanceof tc.HTTPError &&
-                        (err.httpStatusCode === 403 || err.httpStatusCode === 429)) {
-                        core.info(`Received HTTP status code ${err.httpStatusCode}. This usually indicates the rate limit has been exceeded`);
-                    }
-                    else {
-                        core.info(err.message);
-                    }
-                    core.debug((_a = err.stack) !== null && _a !== void 0 ? _a : 'empty stack');
-                    core.info('Falling back to download directly from Node');
+                else {
+                    core.info('Not found in manifest. Falling back to download directly from Node');
                 }
-                if (!toolPath) {
-                    const nodeJsVersions = yield this.getNodeJsVersions();
-                    const versions = this.filterVersions(nodeJsVersions);
-                    const evaluatedVersion = this.evaluateVersions(versions);
-                    if (!evaluatedVersion) {
-                        throw new Error(`Unable to find Node version '${this.nodeInfo.versionSpec}' for platform ${this.osPlat} and architecture ${this.nodeInfo.arch}.`);
-                    }
-                    const toolName = this.getNodejsDistInfo(evaluatedVersion);
-                    toolPath = yield this.downloadNodejs(toolName);
+            }
+            catch (err) {
+                // Rate limit?
+                if (err instanceof tc.HTTPError &&
+                    (err.httpStatusCode === 403 || err.httpStatusCode === 429)) {
+                    core.info(`Received HTTP status code ${err.httpStatusCode}. This usually indicates the rate limit has been exceeded`);
                 }
+                else {
+                    core.info(err.message);
+                }
+                core.debug((_a = err.stack) !== null && _a !== void 0 ? _a : 'empty stack');
+                core.info('Falling back to download directly from Node');
+            }
+            if (!toolPath) {
+                toolPath = yield this.downloadDirectlyFromNode();
             }
             if (this.osPlat != 'win32') {
                 toolPath = path_1.default.join(toolPath, 'bin');
             }
             core.addPath(toolPath);
+        });
+    }
+    addToolPath(toolPath) {
+        if (this.osPlat != 'win32') {
+            toolPath = path_1.default.join(toolPath, 'bin');
+        }
+        core.addPath(toolPath);
+    }
+    downloadDirectlyFromNode() {
+        return __awaiter(this, void 0, void 0, function* () {
+            const nodeJsVersions = yield this.getNodeJsVersions();
+            const versions = this.filterVersions(nodeJsVersions);
+            const evaluatedVersion = this.evaluateVersions(versions);
+            if (!evaluatedVersion) {
+                throw new Error(`Unable to find Node version '${this.nodeInfo.versionSpec}' for platform ${this.osPlat} and architecture ${this.nodeInfo.arch}.`);
+            }
+            const toolName = this.getNodejsDistInfo(evaluatedVersion);
+            try {
+                const toolPath = yield this.downloadNodejs(toolName);
+                return toolPath;
+            }
+            catch (error) {
+                if (error instanceof tc.HTTPError && error.httpStatusCode === 404) {
+                    core.info(`Node version ${this.nodeInfo.versionSpec} for platform ${this.osPlat} and architecture ${this.nodeInfo.arch} was found but failed to download. ` +
+                        'This usually happens when downloadable binaries are not fully updated at https://nodejs.org/. ' +
+                        'To resolve this issue you may either fall back to the older version or try again later.');
+                }
+                throw error;
+            }
         });
     }
     evaluateVersions(versions) {

--- a/src/distributions/official_builds/official_builds.ts
+++ b/src/distributions/official_builds/official_builds.ts
@@ -148,7 +148,7 @@ export default class OfficialBuilds extends BaseDistribution {
       return toolPath;
     } catch (error) {
       if (error instanceof tc.HTTPError && error.httpStatusCode === 404) {
-        core.info(
+        core.warning(
           `Node version ${this.nodeInfo.versionSpec} for platform ${this.osPlat} and architecture ${this.nodeInfo.arch} was found but failed to download. ` +
             'This usually happens when downloadable binaries are not fully updated at https://nodejs.org/. ' +
             'To resolve this issue you may either fall back to the older version or try again later.'


### PR DESCRIPTION
**Description:**
Adds notice when specific version was found but could not be downloaded because of 404 error (see issue)

**Related issue:**
https://github.com/actions/setup-node/issues/717

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.