### PR TITLE
Add `package.json` to `node-version-file` list of examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ See [action.yml](action.yml)
     # Examples: 12.x, 10.15.1, >=10.15.0, lts/Hydrogen, 16-nightly, latest, node
     node-version: ''
 
-    # File containing the version Spec of the version to use.  Examples: .nvmrc, .node-version, .tool-versions.
+    # File containing the version Spec of the version to use.  Examples: package.json, .nvmrc, .node-version, .tool-versions.
     # If node-version and node-version-file are both provided the action will use version from node-version. 
     node-version-file: ''
 

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   node-version:
     description: 'Version Spec of the version to use. Examples: 12.x, 10.15.1, >=10.15.0.'
   node-version-file:
-    description: 'File containing the version Spec of the version to use.  Examples: .nvmrc, .node-version, .tool-versions.'
+    description: 'File containing the version Spec of the version to use.  Examples: package.json, .nvmrc, .node-version, .tool-versions.'
   architecture:
     description: 'Target architecture for Node to use. Examples: x86, x64. Will use system architecture by default.'
   check-latest:


### PR DESCRIPTION
**Description:**
Add `package.json` to `node-version-file` list of examples, because that file is very wide-spread in documentation around the internet for storing versions. Without this change, there's no mention of this possibility in the readme/action.yml file.

The functionality already exists: https://github.com/actions/setup-node/blob/8f152de45cc393bb48ce5d89d36b731f54556e65/src/util.ts#L10
With tests: https://github.com/actions/setup-node/blob/8f152de45cc393bb48ce5d89d36b731f54556e65/__tests__/main.test.ts#L103

**Related issue:** None.

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.