### PR TITLE
Ignore engines check in Yarn 1 e2e-cache tests

### DIFF
--- a/.github/workflows/e2e-cache.yml
+++ b/.github/workflows/e2e-cache.yml
@@ -93,7 +93,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --ignore-engines
       - name: Verify node and yarn
         run: __tests__/verify-node.sh "${{ matrix.node-version }}"
         shell: bash


### PR DESCRIPTION
**Description:**
Ignore engines check in Yarn 1 e2e-cache tests

**Related issue:**
Fixes: https://github.com/actions/setup-node/issues/881

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.