### PR TITLE
Added option to enable corepack

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,22 +26,22 @@ See [action.yml](action.yml)
     node-version: ''
 
     # File containing the version Spec of the version to use.  Examples: .nvmrc, .node-version, .tool-versions.
-    # If node-version and node-version-file are both provided the action will use version from node-version. 
+    # If node-version and node-version-file are both provided the action will use version from node-version.
     node-version-file: ''
 
-    # Set this option if you want the action to check for the latest available version 
+    # Set this option if you want the action to check for the latest available version
     # that satisfies the version spec.
-    # It will only get affect for lts Nodejs versions (12.x, >=10.15.0, lts/Hydrogen). 
+    # It will only get affect for lts Nodejs versions (12.x, >=10.15.0, lts/Hydrogen).
     # Default: false
     check-latest: false
 
     # Target architecture for Node to use. Examples: x86, x64. Will use system architecture by default.
-    # Default: ''. The action use system architecture by default 
+    # Default: ''. The action use system architecture by default
     architecture: ''
 
-    # Used to pull node distributions from https://github.com/actions/node-versions. 
-    # Since there's a default, this is typically not supplied by the user. 
-    # When running this action on github.com, the default value is sufficient. 
+    # Used to pull node distributions from https://github.com/actions/node-versions.
+    # Since there's a default, this is typically not supplied by the user.
+    # When running this action on github.com, the default value is sufficient.
     # When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
     #
     # We recommend using a service account with the least permissions necessary. Also
@@ -57,18 +57,18 @@ See [action.yml](action.yml)
     # Default: ''
     cache: ''
 
-    # Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc. 
-    # It will generate hash from the target file for primary key. It works only If cache is specified.  
+    # Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc.
+    # It will generate hash from the target file for primary key. It works only If cache is specified.
     # Supports wildcards or a list of file names for caching multiple dependencies.
     # Default: ''
     cache-dependency-path: ''
 
-    # Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, 
+    # Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file,
     # and set up auth to read in from env.NODE_AUTH_TOKEN.
     # Default: ''
     registry-url: ''
 
-    # Optional scope for authenticating against scoped registries. 
+    # Optional scope for authenticating against scoped registries.
     # Will fall back to the repository owner when using the GitHub Packages registry (https://npm.pkg.github.com/).
     # Default: ''
     scope: ''
@@ -203,6 +203,7 @@ If the runner is not able to access github.com, any Nodejs versions requested du
  - [Publishing to npmjs and GPR with npm](docs/advanced-usage.md#publish-to-npmjs-and-gpr-with-npm)
  - [Publishing to npmjs and GPR with yarn](docs/advanced-usage.md#publish-to-npmjs-and-gpr-with-yarn)
  - [Using private packages](docs/advanced-usage.md#use-private-packages)
+ - [Enabling Corepack](docs/advanced-usage.md#enabling-corepack)
 
 ## License
 

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -300,4 +300,56 @@ describe('main tests', () => {
       );
     });
   });
+
+  describe('corepack flag', () => {
+    it('should not enable corepack when no input', async () => {
+      inputs['corepack'] = '';
+      await main.run();
+      expect(getExecOutputSpy).not.toHaveBeenCalledWith(
+        'corepack',
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
+    it('should not enable corepack when input is "false"', async () => {
+      inputs['corepack'] = 'false';
+      await main.run();
+      expect(getExecOutputSpy).not.toHaveBeenCalledWith(
+        'corepack',
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
+    it('should enable corepack when input is "true"', async () => {
+      inputs['corepack'] = 'true';
+      await main.run();
+      expect(getExecOutputSpy).toHaveBeenCalledWith(
+        'corepack',
+        ['enable'],
+        expect.anything()
+      );
+    });
+
+    it('should enable corepack with a single package manager', async () => {
+      inputs['corepack'] = 'npm';
+      await main.run();
+      expect(getExecOutputSpy).toHaveBeenCalledWith(
+        'corepack',
+        ['enable', 'npm'],
+        expect.anything()
+      );
+    });
+
+    it('should enable corepack with multiple package managers', async () => {
+      inputs['corepack'] = 'npm yarn';
+      await main.run();
+      expect(getExecOutputSpy).toHaveBeenCalledWith(
+        'corepack',
+        ['enable', 'npm', 'yarn'],
+        expect.anything()
+      );
+    });
+  });
 });

--- a/__tests__/official-installer.test.ts
+++ b/__tests__/official-installer.test.ts
@@ -825,4 +825,36 @@ describe('setup-node', () => {
       }
     );
   });
+
+  describe('corepack flag', () => {
+    it('use corepack if specified', async () => {
+      inputs['corepack'] = 'true';
+      await main.run();
+      expect(getExecOutputSpy).toHaveBeenCalledWith(
+        'corepack',
+        ['enable'],
+        expect.anything()
+      );
+    });
+
+    it('use corepack with given package manager', async () => {
+      inputs['corepack'] = 'npm';
+      await main.run();
+      expect(getExecOutputSpy).toHaveBeenCalledWith(
+        'corepack',
+        ['enable', 'npm'],
+        expect.anything()
+      );
+    });
+
+    it('use corepack with multiple package managers', async () => {
+      inputs['corepack'] = 'npm yarn';
+      await main.run();
+      expect(getExecOutputSpy).toHaveBeenCalledWith(
+        'corepack',
+        ['enable', 'npm', 'yarn'],
+        expect.anything()
+      );
+    });
+  });
 });

--- a/__tests__/official-installer.test.ts
+++ b/__tests__/official-installer.test.ts
@@ -825,36 +825,4 @@ describe('setup-node', () => {
       }
     );
   });
-
-  describe('corepack flag', () => {
-    it('use corepack if specified', async () => {
-      inputs['corepack'] = 'true';
-      await main.run();
-      expect(getExecOutputSpy).toHaveBeenCalledWith(
-        'corepack',
-        ['enable'],
-        expect.anything()
-      );
-    });
-
-    it('use corepack with given package manager', async () => {
-      inputs['corepack'] = 'npm';
-      await main.run();
-      expect(getExecOutputSpy).toHaveBeenCalledWith(
-        'corepack',
-        ['enable', 'npm'],
-        expect.anything()
-      );
-    });
-
-    it('use corepack with multiple package managers', async () => {
-      inputs['corepack'] = 'npm yarn';
-      await main.run();
-      expect(getExecOutputSpy).toHaveBeenCalledWith(
-        'corepack',
-        ['enable', 'npm', 'yarn'],
-        expect.anything()
-      );
-    });
-  });
 });

--- a/action.yml
+++ b/action.yml
@@ -25,10 +25,13 @@ inputs:
     description: 'Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm.'
   cache-dependency-path:
     description: 'Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc. Supports wildcards or a list of file names for caching multiple dependencies.'
+  corepack:
+    description: 'Used to specify whether to enable Corepack. Set to true to enable all package managers or set it to one or more package manager names separated by a space. Supported package manager names: npm, yarn, pnpm.'
+    default: 'false'
 # TODO: add input to control forcing to pull from cloud or dist.
 #       escape valve for someone having issues or needing the absolute latest which isn't cached yet
 outputs:
-  cache-hit: 
+  cache-hit:
     description: 'A boolean value to indicate if a cache was hit.'
   node-version:
     description: 'The installed node version.'

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -83321,7 +83321,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.unique = exports.printEnvDetailsAndSetOutput = exports.parseNodeVersionFile = void 0;
+exports.enableCorepack = exports.unique = exports.printEnvDetailsAndSetOutput = exports.parseNodeVersionFile = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const exec = __importStar(__nccwpck_require__(1514));
 function parseNodeVersionFile(contents) {
@@ -83393,6 +83393,21 @@ const unique = () => {
     };
 };
 exports.unique = unique;
+function enableCorepack(input) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const corepackArgs = ['enable'];
+        if (input.length > 0 && input !== 'false') {
+            if (input !== 'true') {
+                const packageManagers = input.split(' ');
+                corepackArgs.push(...packageManagers);
+            }
+            yield exec.getExecOutput('corepack', corepackArgs, {
+                ignoreReturnCode: true
+            });
+        }
+    });
+}
+exports.enableCorepack = enableCorepack;
 
 
 /***/ }),

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -93698,6 +93698,8 @@ function run() {
             if (registryUrl) {
                 auth.configAuthentication(registryUrl, alwaysAuth);
             }
+            const corepack = core.getInput('corepack') || 'false';
+            yield (0, util_1.enableCorepack)(corepack);
             if (cache && (0, cache_utils_1.isCacheFeatureAvailable)()) {
                 core.saveState(constants_1.State.CachePackageManager, cache);
                 const cacheDependencyPath = core.getInput('cache-dependency-path');
@@ -93775,7 +93777,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.unique = exports.printEnvDetailsAndSetOutput = exports.parseNodeVersionFile = void 0;
+exports.enableCorepack = exports.unique = exports.printEnvDetailsAndSetOutput = exports.parseNodeVersionFile = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const exec = __importStar(__nccwpck_require__(1514));
 function parseNodeVersionFile(contents) {
@@ -93847,6 +93849,21 @@ const unique = () => {
     };
 };
 exports.unique = unique;
+function enableCorepack(input) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const corepackArgs = ['enable'];
+        if (input.length > 0 && input !== 'false') {
+            if (input !== 'true') {
+                const packageManagers = input.split(' ');
+                corepackArgs.push(...packageManagers);
+            }
+            yield exec.getExecOutput('corepack', corepackArgs, {
+                ignoreReturnCode: true
+            });
+        }
+    });
+}
+exports.enableCorepack = enableCorepack;
 
 
 /***/ }),

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -416,3 +416,32 @@ Please refer to the [Ensuring workflow access to your package - Configuring a pa
 
 ### always-auth input
 The always-auth input sets `always-auth=true` in .npmrc file. With this option set [npm](https://docs.npmjs.com/cli/v6/using-npm/config#always-auth)/yarn sends the authentication credentials when making a request to the registries.
+
+## Enabling Corepack
+You can enable [Corepack](https://github.com/nodejs/corepack) by using the `corepack` input. You can then use `pnpm` and `yarn` commands in your project.
+
+```yaml
+steps:
+- uses: actions/checkout@v3
+- uses: actions/setup-node@v3
+  with:
+    node-version: '16.x'
+    corepack: true
+- name: Install dependencies
+  run: yarn install --immutable
+```
+
+You can also pass package manager names separated by a space to enable corepack for specific package managers only.
+
+```yaml
+steps:
+- uses: actions/checkout@v3
+- uses: actions/setup-node@v3
+  with:
+    node-version: '16.x'
+    corepack: yarn pnpm
+- name: Install dependencies
+  run: yarn install --immutable
+```
+
+This option by default is `false` as Corepack is still in experimental phase.

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -157,7 +157,7 @@ jobs:
 
 ## Nightly versions
 
-You can specify a nightly version to download it from https://nodejs.org/download/nightly. 
+You can specify a nightly version to download it from https://nodejs.org/download/nightly.
 
 ### Install the nightly build for a major version
 
@@ -265,7 +265,7 @@ steps:
 - run: pnpm test
 ```
 
-> **Note**: By default `--frozen-lockfile` option is passed starting from pnpm `6.10.x`. It will be automatically added if you run it on [CI](https://pnpm.io/cli/install#--frozen-lockfile). 
+> **Note**: By default `--frozen-lockfile` option is passed starting from pnpm `6.10.x`. It will be automatically added if you run it on [CI](https://pnpm.io/cli/install#--frozen-lockfile).
 > If the `pnpm-lock.yaml` file changes then pass `--frozen-lockfile` option.
 
 
@@ -425,7 +425,7 @@ steps:
 - uses: actions/checkout@v3
 - uses: actions/setup-node@v3
   with:
-    node-version: '16.x'
+    node-version: '18.x'
     corepack: true
 - name: Install dependencies
   run: yarn install --immutable
@@ -438,7 +438,7 @@ steps:
 - uses: actions/checkout@v3
 - uses: actions/setup-node@v3
   with:
-    node-version: '16.x'
+    node-version: '18.x'
     corepack: yarn pnpm
 - name: Install dependencies
   run: yarn install --immutable

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -422,8 +422,8 @@ You can enable [Corepack](https://github.com/nodejs/corepack) by using the `core
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
-- uses: actions/setup-node@v3
+- uses: actions/checkout@v4
+- uses: actions/setup-node@v4
   with:
     node-version: '18.x'
     corepack: true
@@ -435,8 +435,8 @@ You can also pass package manager names separated by a space to enable corepack 
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
-- uses: actions/setup-node@v3
+- uses: actions/checkout@v4
+- uses: actions/setup-node@v4
   with:
     node-version: '18.x'
     corepack: yarn pnpm

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,11 @@ import * as path from 'path';
 import {restoreCache} from './cache-restore';
 import {isCacheFeatureAvailable} from './cache-utils';
 import {getNodejsDistribution} from './distributions/installer-factory';
-import {parseNodeVersionFile, printEnvDetailsAndSetOutput} from './util';
+import {
+  parseNodeVersionFile,
+  printEnvDetailsAndSetOutput,
+  enableCorepack
+} from './util';
 import {State} from './constants';
 
 export async function run() {
@@ -59,6 +63,9 @@ export async function run() {
     if (registryUrl) {
       auth.configAuthentication(registryUrl, alwaysAuth);
     }
+
+    const corepack = core.getInput('corepack') || 'false';
+    await enableCorepack(corepack);
 
     if (cache && isCacheFeatureAvailable()) {
       core.saveState(State.CachePackageManager, cache);

--- a/src/util.ts
+++ b/src/util.ts
@@ -70,3 +70,16 @@ export const unique = () => {
     return true;
   };
 };
+
+export async function enableCorepack(input: string): Promise<void> {
+  const corepackArgs = ['enable'];
+  if (input.length > 0 && input !== 'false') {
+    if (input !== 'true') {
+      const packageManagers = input.split(' ');
+      corepackArgs.push(...packageManagers);
+    }
+    await exec.getExecOutput('corepack', corepackArgs, {
+      ignoreReturnCode: true
+    });
+  }
+}


### PR DESCRIPTION
**Description:**

_Updated version of corepack support due to the original author [not having time to refactor the original PR](https://github.com/actions/setup-node/pull/651#issuecomment-1737078570)_

Adds `corepack` option in which workflows can specify `true` or a list of package managers to enable corepack accordingly. 

**Related issue:**
- Supersedes https://github.com/actions/setup-node/pull/651
- Closes https://github.com/actions/setup-node/issues/531


**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.