### PR TITLE
Explicitly exit the process to not wait for hanging promises

### DIFF
--- a/__tests__/canary-installer.test.ts
+++ b/__tests__/canary-installer.test.ts
@@ -46,6 +46,7 @@ describe('setup-node', () => {
   let isCacheActionAvailable: jest.SpyInstance;
   let getExecOutputSpy: jest.SpyInstance;
   let getJsonSpy: jest.SpyInstance;
+  let processExitSpy: jest.SpyInstance;
 
   beforeEach(() => {
     // @actions/core
@@ -63,6 +64,9 @@ describe('setup-node', () => {
     archSpy = jest.spyOn(osm, 'arch');
     archSpy.mockImplementation(() => os['arch']);
     execSpy = jest.spyOn(cp, 'execSync');
+    processExitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation((() => {}) as () => never);
 
     // @actions/tool-cache
     findSpy = jest.spyOn(tc, 'find');

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -35,6 +35,8 @@ describe('main tests', () => {
 
   let setupNodeJsSpy: jest.SpyInstance;
 
+  let processExitSpy: jest.SpyInstance;
+
   beforeEach(() => {
     inputs = {};
 
@@ -72,6 +74,10 @@ describe('main tests', () => {
 
     setupNodeJsSpy = jest.spyOn(OfficialBuilds.prototype, 'setupNodeJs');
     setupNodeJsSpy.mockImplementation(() => {});
+
+    processExitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation((() => {}) as () => never);
   });
 
   afterEach(() => {
@@ -256,6 +262,12 @@ describe('main tests', () => {
       expect(cnSpy).toHaveBeenCalledWith(
         `::error::The specified node version file at: ${versionFilePath} does not exist${osm.EOL}`
       );
+    });
+
+    it('should call process.exit() explicitly after running', async () => {
+      await main.run();
+
+      expect(processExitSpy).toHaveBeenCalled();
     });
   });
 

--- a/__tests__/nightly-installer.test.ts
+++ b/__tests__/nightly-installer.test.ts
@@ -46,6 +46,7 @@ describe('setup-node', () => {
   let isCacheActionAvailable: jest.SpyInstance;
   let getExecOutputSpy: jest.SpyInstance;
   let getJsonSpy: jest.SpyInstance;
+  let processExitSpy: jest.SpyInstance;
 
   beforeEach(() => {
     // @actions/core
@@ -64,6 +65,9 @@ describe('setup-node', () => {
     archSpy = jest.spyOn(osm, 'arch');
     archSpy.mockImplementation(() => os['arch']);
     execSpy = jest.spyOn(cp, 'execSync');
+    processExitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation((() => {}) as () => never);
 
     // @actions/tool-cache
     findSpy = jest.spyOn(tc, 'find');

--- a/__tests__/official-installer.test.ts
+++ b/__tests__/official-installer.test.ts
@@ -46,6 +46,7 @@ describe('setup-node', () => {
   let isCacheActionAvailable: jest.SpyInstance;
   let getExecOutputSpy: jest.SpyInstance;
   let getJsonSpy: jest.SpyInstance;
+  let processExitSpy: jest.SpyInstance;
 
   beforeEach(() => {
     // @actions/core
@@ -63,6 +64,9 @@ describe('setup-node', () => {
     archSpy = jest.spyOn(osm, 'arch');
     archSpy.mockImplementation(() => os['arch']);
     execSpy = jest.spyOn(cp, 'execSync');
+    processExitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation((() => {}) as () => never);
 
     // @actions/tool-cache
     findSpy = jest.spyOn(tc, 'find');

--- a/__tests__/rc-installer.test.ts
+++ b/__tests__/rc-installer.test.ts
@@ -41,6 +41,7 @@ describe('setup-node', () => {
   let isCacheActionAvailable: jest.SpyInstance;
   let getExecOutputSpy: jest.SpyInstance;
   let getJsonSpy: jest.SpyInstance;
+  let processExitSpy: jest.SpyInstance;
 
   beforeEach(() => {
     // @actions/core
@@ -58,6 +59,9 @@ describe('setup-node', () => {
     archSpy = jest.spyOn(osm, 'arch');
     archSpy.mockImplementation(() => os['arch']);
     execSpy = jest.spyOn(cp, 'execSync');
+    processExitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation((() => {}) as () => never);
 
     // @actions/tool-cache
     findSpy = jest.spyOn(tc, 'find');

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -93711,6 +93711,9 @@ function run() {
         catch (err) {
             core.setFailed(err.message);
         }
+        // Explicit process.exit() to not wait for hanging promises,
+        // see https://github.com/actions/setup-node/issues/878
+        process.exit();
     });
 }
 exports.run = run;

--- a/src/main.ts
+++ b/src/main.ts
@@ -77,6 +77,10 @@ export async function run() {
   } catch (err) {
     core.setFailed((err as Error).message);
   }
+
+  // Explicit process.exit() to not wait for hanging promises,
+  // see https://github.com/actions/setup-node/issues/878
+  process.exit();
 }
 
 function resolveVersionInput(): string {


### PR DESCRIPTION
**Description:**
Since Node.js 19, the default for `keepAlive` was changed from `false` to `true`. As explained in [this similar issue for the Ruby setup action](https://github.com/ruby/setup-ruby/issues/543#issuecomment-1793608370), this causes the Post setup Node action to hang for somewhere between 1 and 5 minutes after running. This PR explicitly exits the process once the `run` function is completed, to not wait for hanging promises.

**Related issue:**
See https://github.com/actions/setup-node/issues/878

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.