### PR TITLE
Upgrade @actions/cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/cache": "^3.0.4",
+        "@actions/cache": "^3.2.2",
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.0",
         "@actions/github": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "GitHub",
   "license": "MIT",
   "dependencies": {
-    "@actions/cache": "^3.0.4",
+    "@actions/cache": "^3.2.2",
     "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.0",
     "@actions/github": "^5.1.1",


### PR DESCRIPTION
**Description:**
I've upgraded minor version of @actions/cache in order to solve the issue 

"Intermittently, the setup-node action times out after 60 minutes. Logs indicate that it's restoring yarn cache"

**Related issue:**
[link to the related issue.](https://github.com/actions/setup-node/issues/733)

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.