### PR TITLE
Support AGENT_TOOLSDIRECTORY as in setup-python action

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -94211,6 +94211,7 @@ const util_1 = __nccwpck_require__(2629);
 const constants_1 = __nccwpck_require__(9042);
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
+        var _a;
         try {
             //
             // Version is optional.  If supplied, install / use from the tool cache
@@ -94227,6 +94228,10 @@ function run() {
             if (!arch) {
                 arch = os_1.default.arch();
             }
+            if ((_a = process.env.AGENT_TOOLSDIRECTORY) === null || _a === void 0 ? void 0 : _a.trim()) {
+                process.env['RUNNER_TOOL_CACHE'] = process.env['AGENT_TOOLSDIRECTORY'];
+            }
+            core.debug(`Node is expected to be installed into ${process.env['RUNNER_TOOL_CACHE']}`);
             if (version) {
                 const token = core.getInput('token');
                 const auth = !token ? undefined : `token ${token}`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,14 @@ export async function run() {
       arch = os.arch();
     }
 
+    if (process.env.AGENT_TOOLSDIRECTORY?.trim()) {
+      process.env['RUNNER_TOOL_CACHE'] = process.env['AGENT_TOOLSDIRECTORY'];
+    }
+
+    core.debug(
+      `Node is expected to be installed into ${process.env['RUNNER_TOOL_CACHE']}`
+    );
+
     if (version) {
       const token = core.getInput('token');
       const auth = !token ? undefined : `token ${token}`;


### PR DESCRIPTION
**Description:**

We needs to run a custom workflow to populate tools cache data for self-hosted runners. However it could not override the default downloading location on setup-node action. 

Setup-python already has support for this use case. We'd like to have the same logic applied on this action.

**Related issue:**
[Add link to the related issue.](https://github.com/actions/setup-node/issues/1039)

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.