### PR TITLE
Correct version string

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See [action.yml](action.yml)
 - uses: actions/setup-node@v4
   with:
     # Version Spec of the version to use in SemVer notation.
-    # It also admits such aliases as lts, latest, nightly and canary builds
+    # It also admits such aliases as lts/*, latest, nightly and canary builds
     # Examples: 12.x, 10.15.1, >=10.15.0, lts/Hydrogen, 16-nightly, latest, node
     node-version: ''
 


### PR DESCRIPTION
**Description:**

Fixes documentation.

lts is not a valid version

source: https://github.com/fulldecent/github-pages-template/actions/runs/10636170060/job/29487382212


**Related issue:**
Add link to the related issue.

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.