### PR TITLE
Fix: windows arm64 setup

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -93883,7 +93883,7 @@ class BaseDistribution {
                 }
                 throw err;
             }
-            const toolPath = yield this.extractArchive(downloadPath, info);
+            const toolPath = yield this.extractArchive(downloadPath, info, true);
             core.info('Done');
             return toolPath;
         });
@@ -93933,7 +93933,7 @@ class BaseDistribution {
             return toolPath;
         });
     }
-    extractArchive(downloadPath, info) {
+    extractArchive(downloadPath, info, isOfficialArchive) {
         return __awaiter(this, void 0, void 0, function* () {
             //
             // Extract
@@ -93948,7 +93948,7 @@ class BaseDistribution {
                 // on Windows runners without PowerShell Core.
                 //
                 // For default PowerShell Windows it should contain extension type to unpack it.
-                if (extension === '.zip') {
+                if (extension === '.zip' && isOfficialArchive) {
                     const renamedArchive = `${downloadPath}.zip`;
                     fs_1.default.renameSync(downloadPath, renamedArchive);
                     extPath = yield tc.extractZip(renamedArchive);
@@ -94186,7 +94186,7 @@ class OfficialBuilds extends base_distribution_1.default {
                     core.info(`Acquiring ${versionInfo.resolvedVersion} - ${versionInfo.arch} from ${versionInfo.downloadUrl}`);
                     downloadPath = yield tc.downloadTool(versionInfo.downloadUrl, undefined, this.nodeInfo.auth);
                     if (downloadPath) {
-                        toolPath = yield this.extractArchive(downloadPath, versionInfo);
+                        toolPath = yield this.extractArchive(downloadPath, versionInfo, false);
                     }
                 }
                 else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4429,12 +4429,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/src/distributions/base-distribution.ts
+++ b/src/distributions/base-distribution.ts
@@ -150,7 +150,7 @@ export default abstract class BaseDistribution {
       throw err;
     }
 
-    const toolPath = await this.extractArchive(downloadPath, info);
+    const toolPath = await this.extractArchive(downloadPath, info, true);
     core.info('Done');
 
     return toolPath;
@@ -210,7 +210,8 @@ export default abstract class BaseDistribution {
 
   protected async extractArchive(
     downloadPath: string,
-    info: INodeVersionInfo | null
+    info: INodeVersionInfo | null,
+    isOfficialArchive?: boolean
   ) {
     //
     // Extract
@@ -225,7 +226,7 @@ export default abstract class BaseDistribution {
       // on Windows runners without PowerShell Core.
       //
       // For default PowerShell Windows it should contain extension type to unpack it.
-      if (extension === '.zip') {
+      if (extension === '.zip' && isOfficialArchive) {
         const renamedArchive = `${downloadPath}.zip`;
         fs.renameSync(downloadPath, renamedArchive);
         extPath = await tc.extractZip(renamedArchive);

--- a/src/distributions/official_builds/official_builds.ts
+++ b/src/distributions/official_builds/official_builds.ts
@@ -88,7 +88,11 @@ export default class OfficialBuilds extends BaseDistribution {
         );
 
         if (downloadPath) {
-          toolPath = await this.extractArchive(downloadPath, versionInfo);
+          toolPath = await this.extractArchive(
+            downloadPath,
+            versionInfo,
+            false
+          );
         }
       } else {
         core.info(


### PR DESCRIPTION
**Description:**

- This update ensures that Windows ARM64 archives are correctly processed, preventing extraction errors and improving the reliability of the setup node process for Windows ARM64 environments.

- Bumps [micromatch](https://github.com/micromatch/micromatch) from 4.0.5 to 4.0.8

**Related issue:**
#1121 

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.