### PR TITLE
fix: add restore key for all package managers

### DIFF
--- a/src/cache-restore.ts
+++ b/src/cache-restore.ts
@@ -44,19 +44,7 @@ export const restoreCache = async (
 
   core.saveState(State.CachePrimaryKey, primaryKey);
 
-  const isManagedByYarnBerry = await repoHasYarnBerryManagedDependencies(
-    packageManagerInfo,
-    cacheDependencyPath
-  );
-  let cacheKey: string | undefined;
-  if (isManagedByYarnBerry) {
-    core.info(
-      'All dependencies are managed locally by yarn3, the previous cache can be used'
-    );
-    cacheKey = await cache.restoreCache(cachePaths, primaryKey, [keyPrefix]);
-  } else {
-    cacheKey = await cache.restoreCache(cachePaths, primaryKey);
-  }
+  const cacheKey = await cache.restoreCache(cachePaths, primaryKey, [keyPrefix]);
 
   core.setOutput('cache-hit', Boolean(cacheKey));
 


### PR DESCRIPTION
**Description:**
Add cache restore key for all package managers.

According to github cache document [action/cache npm cache](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#input-parameters-for-the-cache-action) npm can use restore key to improve cache restore. And [yarn](https://github.com/actions/cache/blob/main/examples.md#node---yarn) and [yarn2](https://github.com/actions/cache/blob/main/examples.md#node---yarn-2) is also support to use restore-key

[pnpm/action-setup](https://github.com/pnpm/action-setup/tree/v4/?tab=readme-ov-file#use-cache-to-reduce-installation-time) also point out pnpm is support to use restore-key.

**Related issue:**
#1120 

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.