### PR TITLE
Added Node version to cache key

### DIFF
--- a/__tests__/cache-restore.test.ts
+++ b/__tests__/cache-restore.test.ts
@@ -115,7 +115,7 @@ describe('cache-restore', () => {
     it.each([['npm7'], ['npm6'], ['pnpm6'], ['yarn1'], ['yarn2'], ['random']])(
       'Throw an error because %s is not supported',
       async packageManager => {
-        await expect(restoreCache(packageManager, '')).rejects.toThrow(
+        await expect(restoreCache(packageManager, '', '')).rejects.toThrow(
           `Caching for '${packageManager}' is not supported`
         );
       }
@@ -124,13 +124,13 @@ describe('cache-restore', () => {
 
   describe('Restore dependencies', () => {
     it.each([
-      ['yarn', '2.1.2', yarnFileHash],
-      ['yarn', '1.2.3', yarnFileHash],
-      ['npm', '', npmFileHash],
-      ['pnpm', '', pnpmFileHash]
+      ['yarn', '2.1.2', yarnFileHash, '22'],
+      ['yarn', '1.2.3', yarnFileHash, '20.17'],
+      ['npm', '', npmFileHash, '22.12'],
+      ['pnpm', '', pnpmFileHash, '18']
     ])(
       'restored dependencies for %s',
-      async (packageManager, toolVersion, fileHash) => {
+      async (packageManager, toolVersion, fileHash, nodeVersion) => {
         getCommandOutputSpy.mockImplementation((command: string) => {
           if (command.includes('version')) {
             return toolVersion;
@@ -139,10 +139,10 @@ describe('cache-restore', () => {
           }
         });
 
-        await restoreCache(packageManager, '');
+        await restoreCache(packageManager, '', nodeVersion);
         expect(hashFilesSpy).toHaveBeenCalled();
         expect(infoSpy).toHaveBeenCalledWith(
-          `Cache restored from key: node-cache-${platform}-${arch}-${packageManager}-${fileHash}`
+          `Cache restored from key: node-cache-${platform}-${arch}-${nodeVersion}-${packageManager}-${fileHash}`
         );
         expect(infoSpy).not.toHaveBeenCalledWith(
           `${packageManager} cache is not found`
@@ -170,7 +170,7 @@ describe('cache-restore', () => {
         });
 
         restoreCacheSpy.mockImplementationOnce(() => undefined);
-        await restoreCache(packageManager, '');
+        await restoreCache(packageManager, '', '');
         expect(hashFilesSpy).toHaveBeenCalled();
         expect(infoSpy).toHaveBeenCalledWith(
           `${packageManager} cache is not found`

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -93306,7 +93306,7 @@ const fs_1 = __importDefault(__nccwpck_require__(7147));
 const os_1 = __importDefault(__nccwpck_require__(2037));
 const constants_1 = __nccwpck_require__(9042);
 const cache_utils_1 = __nccwpck_require__(1678);
-const restoreCache = (packageManager, cacheDependencyPath) => __awaiter(void 0, void 0, void 0, function* () {
+const restoreCache = (packageManager, cacheDependencyPath, nodeVersion) => __awaiter(void 0, void 0, void 0, function* () {
     const packageManagerInfo = yield (0, cache_utils_1.getPackageManagerInfo)(packageManager);
     if (!packageManagerInfo) {
         throw new Error(`Caching for '${packageManager}' is not supported`);
@@ -93322,7 +93322,7 @@ const restoreCache = (packageManager, cacheDependencyPath) => __awaiter(void 0, 
     if (!fileHash) {
         throw new Error('Some specified paths were not resolved, unable to cache dependencies.');
     }
-    const keyPrefix = `node-cache-${platform}-${arch}-${packageManager}`;
+    const keyPrefix = `node-cache-${platform}-${arch}-${nodeVersion}-${packageManager}`;
     const primaryKey = `${keyPrefix}-${fileHash}`;
     core.debug(`primary key is ${primaryKey}`);
     core.saveState(constants_1.State.CachePrimaryKey, primaryKey);
@@ -94472,7 +94472,7 @@ function run() {
             if (cache && (0, cache_utils_1.isCacheFeatureAvailable)()) {
                 core.saveState(constants_1.State.CachePackageManager, cache);
                 const cacheDependencyPath = core.getInput('cache-dependency-path');
-                yield (0, cache_restore_1.restoreCache)(cache, cacheDependencyPath);
+                yield (0, cache_restore_1.restoreCache)(cache, cacheDependencyPath, version);
             }
             const matchersPath = path.join(__dirname, '../..', '.github');
             core.info(`##[add-matcher]${path.join(matchersPath, 'tsc.json')}`);

--- a/src/cache-restore.ts
+++ b/src/cache-restore.ts
@@ -15,7 +15,8 @@ import {
 
 export const restoreCache = async (
   packageManager: string,
-  cacheDependencyPath: string
+  cacheDependencyPath: string,
+  nodeVersion: string
 ) => {
   const packageManagerInfo = await getPackageManagerInfo(packageManager);
   if (!packageManagerInfo) {
@@ -40,7 +41,7 @@ export const restoreCache = async (
     );
   }
 
-  const keyPrefix = `node-cache-${platform}-${arch}-${packageManager}`;
+  const keyPrefix = `node-cache-${platform}-${arch}-${nodeVersion}-${packageManager}`;
   const primaryKey = `${keyPrefix}-${fileHash}`;
   core.debug(`primary key is ${primaryKey}`);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,7 +62,7 @@ export async function run() {
     if (cache && isCacheFeatureAvailable()) {
       core.saveState(State.CachePackageManager, cache);
       const cacheDependencyPath = core.getInput('cache-dependency-path');
-      await restoreCache(cache, cacheDependencyPath);
+      await restoreCache(cache, cacheDependencyPath, version);
     }
 
     const matchersPath = path.join(__dirname, '../..', '.github');


### PR DESCRIPTION
**Description:**
The Node.js version is now included in the cache key to ensure caches are invalidated, and dependencies reinstalled, when changing Node.js versions.

**Related issue:**
Fixes #1171 

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.