### PR TITLE
docs: update pnpm example with caching

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -256,9 +256,11 @@ steps:
 
 steps:
 - uses: actions/checkout@v4
-- uses: pnpm/action-setup@v2
+- uses: pnpm/action-setup@v4
+  name: Install pnpm
   with:
-    version: 6.32.9
+    version: 9
+    run_install: false
 - uses: actions/setup-node@v4
   with:
     node-version: '14'


### PR DESCRIPTION
**Description:**
update the example to not install dependencies twice

**Related issue:**
based on this guide https://github.com/pnpm/action-setup?tab=readme-ov-file#use-cache-to-reduce-installation-time

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.