### PR TITLE
add feature to copy toolPath to node-installation-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ See [action.yml](action.yml)
     # Set always-auth option in npmrc file.
     # Default: ''
     always-auth: ''
+
+    # Set node installation path.
+    # Default: ''
+    node-installation-path: ''
 ```
 <!-- end usage -->
 

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,8 @@ inputs:
     description: 'Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm.'
   cache-dependency-path:
     description: 'Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc. Supports wildcards or a list of file names for caching multiple dependencies.'
+  node-installation-path:
+    description: 'Set node installation path.'
 # TODO: add input to control forcing to pull from cloud or dist.
 #       escape valve for someone having issues or needing the absolute latest which isn't cached yet
 outputs:

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -93684,13 +93684,19 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const tc = __importStar(__nccwpck_require__(7784));
 const semver_1 = __importDefault(__nccwpck_require__(1383));
+const os_1 = __importDefault(__nccwpck_require__(2037));
 const base_distribution_1 = __importDefault(__nccwpck_require__(7));
+const core = __importStar(__nccwpck_require__(2186));
 class BasePrereleaseNodejs extends base_distribution_1.default {
     constructor(nodeInfo) {
         super(nodeInfo);
     }
     findVersionInHostedToolCacheDirectory() {
         let toolPath = '';
+        let nodeInstallationPath = core.getInput('node-installation-path');
+        if (os_1.default.platform() != 'win32') {
+            nodeInstallationPath = nodeInstallationPath.replace(/\\?bin$/, '');
+        }
         const localVersionPaths = tc
             .findAllVersions('node', this.nodeInfo.arch)
             .filter(i => {
@@ -93704,6 +93710,9 @@ class BasePrereleaseNodejs extends base_distribution_1.default {
         const localVersion = this.evaluateVersions(localVersionPaths);
         if (localVersion) {
             toolPath = tc.find('node', localVersion, this.nodeInfo.arch);
+            if (nodeInstallationPath !== '') {
+                this.copyFolder(toolPath, nodeInstallationPath);
+            }
         }
         return toolPath;
     }
@@ -93939,6 +93948,24 @@ class BaseDistribution {
             return toolPath;
         });
     }
+    copyFolder(srcDir, destDir) {
+        if (!fs_1.default.existsSync(destDir)) {
+            fs_1.default.mkdirSync(destDir, { recursive: true });
+        }
+    
+        fs_1.default.readdirSync(srcDir).forEach(file => {
+            const srcFile = path.join(srcDir, file);
+            const destFile = path.join(destDir, file);
+    
+            const stat = fs_1.default.statSync(srcFile);
+    
+            if (stat.isDirectory()) {
+                copyFolder(srcFile, destFile);
+            } else if (stat.isFile()) {
+                fs_1.default.copyFileSync(srcFile, destFile);
+            }
+        });
+    }
     extractArchive(downloadPath, info, isOfficialArchive) {
         return __awaiter(this, void 0, void 0, function* () {
             //
@@ -93947,6 +93974,10 @@ class BaseDistribution {
             core.info('Extracting ...');
             let extPath;
             info = info || {}; // satisfy compiler, never null when reaches here
+            let nodeInstallationPath = core.getInput('node-installation-path');
+            if (this.osPlat != 'win32') {
+                nodeInstallationPath = nodeInstallationPath.replace(/\\?bin$/, '');
+            }
             if (this.osPlat == 'win32') {
                 const extension = this.nodeInfo.arch === 'arm64' ? '.zip' : '.7z';
                 // Rename archive to add extension because after downloading
@@ -93958,15 +93989,24 @@ class BaseDistribution {
                     const renamedArchive = `${downloadPath}.zip`;
                     fs_1.default.renameSync(downloadPath, renamedArchive);
                     extPath = yield tc.extractZip(renamedArchive);
+                    if (nodeInstallationPath !== '') {
+                        this.copyFolder(extPath, nodeInstallationPath);
+                    }
                 }
                 else {
                     const _7zPath = path.join(__dirname, '../..', 'externals', '7zr.exe');
                     extPath = yield tc.extract7z(downloadPath, undefined, _7zPath);
+                    if (nodeInstallationPath !== '') {
+                        this.copyFolder(extPath, nodeInstallationPath);
+                    }
                 }
                 // 7z extracts to folder matching file name
                 const nestedPath = path.join(extPath, path.basename(info.fileName, extension));
                 if (fs_1.default.existsSync(nestedPath)) {
                     extPath = nestedPath;
+                    if (nodeInstallationPath !== '') {
+                        this.copyFolder(extPath, nodeInstallationPath);
+                    }
                 }
             }
             else {
@@ -93975,6 +94015,9 @@ class BaseDistribution {
                     '--strip',
                     '1'
                 ]);
+                if (nodeInstallationPath !== '') {
+                    this.copyFolder(extPath, nodeInstallationPath);
+                }
             }
             //
             // Install into the local tool cache - node extracts with a root folder that matches the fileName downloaded


### PR DESCRIPTION
**Description:**
copy toolPath to node-installation-path.
The real Node PATH can be either toolPath or node-installation-path.

**Related issue:**
See #1161

**Check list:**
- [ v] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.