### PR TITLE
Add cache-key as output

### DIFF
--- a/__tests__/cache-restore.test.ts
+++ b/__tests__/cache-restore.test.ts
@@ -180,6 +180,38 @@ describe('cache-restore', () => {
     );
   });
 
+  describe('Cache key output', () => {
+    const packageManager = 'npm';
+    const cacheDependencyPath = 'package-lock.json';
+    const primaryKey = `node-cache-${platform}-${arch}-${packageManager}-${npmFileHash}`;
+    const cacheKey = `node-cache-${platform}-${arch}-${packageManager}-abc123`;
+
+    beforeEach(() => {
+      getCommandOutputSpy.mockImplementation(command => {
+        if (command.includes('npm config get cache')) return npmCachePath;
+      });
+    });
+
+    it('sets the cache-key output', async () => {
+      restoreCacheSpy.mockResolvedValue(cacheKey);
+      await restoreCache(packageManager, cacheDependencyPath);
+      expect(setOutputSpy).toHaveBeenCalledWith('cache-key', primaryKey);
+    });
+
+    it('sets the cache-hit output to true when cache is found', async () => {
+      restoreCacheSpy.mockResolvedValue(cacheKey);
+      await restoreCache(packageManager, cacheDependencyPath);
+      expect(setOutputSpy).toHaveBeenCalledWith('cache-hit', true);
+    });
+
+    it('sets the cache-hit output to false when cache is not found', async () => {
+      restoreCacheSpy.mockResolvedValue(undefined);
+      await restoreCache(packageManager, cacheDependencyPath);
+
+      expect(setOutputSpy).toHaveBeenCalledWith('cache-hit', false);
+    });
+  });
+
   afterEach(() => {
     jest.resetAllMocks();
     jest.clearAllMocks();

--- a/__tests__/cache-restore.test.ts
+++ b/__tests__/cache-restore.test.ts
@@ -131,6 +131,7 @@ describe('cache-restore', () => {
     ])(
       'restored dependencies for %s',
       async (packageManager, toolVersion, fileHash) => {
+        const expectedCacheKey = `node-cache-${platform}-${arch}-${packageManager}-${fileHash}`;
         getCommandOutputSpy.mockImplementation((command: string) => {
           if (command.includes('version')) {
             return toolVersion;
@@ -142,12 +143,20 @@ describe('cache-restore', () => {
         await restoreCache(packageManager, '');
         expect(hashFilesSpy).toHaveBeenCalled();
         expect(infoSpy).toHaveBeenCalledWith(
-          `Cache restored from key: node-cache-${platform}-${arch}-${packageManager}-${fileHash}`
+          `Cache restored from key: ${expectedCacheKey}`
         );
         expect(infoSpy).not.toHaveBeenCalledWith(
           `${packageManager} cache is not found`
         );
         expect(setOutputSpy).toHaveBeenCalledWith('cache-hit', true);
+        expect(setOutputSpy).toHaveBeenCalledWith(
+          'cache-key',
+          expectedCacheKey
+        );
+        expect(setOutputSpy).toHaveBeenCalledWith(
+          'cache-matched-key',
+          expectedCacheKey
+        );
       }
     );
   });
@@ -161,6 +170,7 @@ describe('cache-restore', () => {
     ])(
       'dependencies are changed %s',
       async (packageManager, toolVersion, fileHash) => {
+        const expectedCacheKey = `node-cache-${platform}-${arch}-${packageManager}-${fileHash}`;
         getCommandOutputSpy.mockImplementation((command: string) => {
           if (command.includes('version')) {
             return toolVersion;
@@ -176,6 +186,14 @@ describe('cache-restore', () => {
           `${packageManager} cache is not found`
         );
         expect(setOutputSpy).toHaveBeenCalledWith('cache-hit', false);
+        expect(setOutputSpy).toHaveBeenCalledWith(
+          'cache-key',
+          expectedCacheKey
+        );
+        expect(setOutputSpy).toHaveBeenCalledWith(
+          'cache-matched-key',
+          undefined
+        );
       }
     );
   });
@@ -209,6 +227,28 @@ describe('cache-restore', () => {
       await restoreCache(packageManager, cacheDependencyPath);
 
       expect(setOutputSpy).toHaveBeenCalledWith('cache-hit', false);
+    });
+
+    it('sets the cache-matched-key output when cache is found', async () => {
+      (cache.restoreCache as jest.Mock).mockResolvedValue(cacheKey);
+
+      await restoreCache(packageManager, cacheDependencyPath);
+
+      expect(core.setOutput).toHaveBeenCalledWith(
+        'cache-matched-key',
+        cacheKey
+      );
+    });
+
+    it('sets the cache-matched-key output to undefined when cache is not found', async () => {
+      (cache.restoreCache as jest.Mock).mockResolvedValue(undefined);
+
+      await restoreCache(packageManager, cacheDependencyPath);
+
+      expect(core.setOutput).toHaveBeenCalledWith(
+        'cache-matched-key',
+        undefined
+      );
     });
   });
 

--- a/__tests__/cache-save.test.ts
+++ b/__tests__/cache-save.test.ts
@@ -27,6 +27,7 @@ describe('run', () => {
   let setFailedSpy: jest.SpyInstance;
   let getStateSpy: jest.SpyInstance;
   let saveCacheSpy: jest.SpyInstance;
+  let setOutputSpy: jest.SpyInstance;
   let getCommandOutputSpy: jest.SpyInstance;
   let hashFilesSpy: jest.SpyInstance;
   let existsSpy: jest.SpyInstance;
@@ -52,6 +53,8 @@ describe('run', () => {
     // cache
     saveCacheSpy = jest.spyOn(cache, 'saveCache');
     saveCacheSpy.mockImplementation(() => undefined);
+
+    setOutputSpy = jest.spyOn(core, 'setOutput');
 
     // glob
     hashFilesSpy = jest.spyOn(glob, 'hashFiles');
@@ -228,6 +231,7 @@ describe('run', () => {
       expect(infoSpy).toHaveBeenLastCalledWith(
         `Cache saved with the key: ${npmFileHash}`
       );
+      expect(core.setOutput).toHaveBeenCalledWith('cache-key', npmFileHash);
       expect(setFailedSpy).not.toHaveBeenCalled();
     });
 
@@ -258,6 +262,7 @@ describe('run', () => {
       expect(infoSpy).toHaveBeenLastCalledWith(
         `Cache saved with the key: ${npmFileHash}`
       );
+      expect(core.setOutput).toHaveBeenCalledWith('cache-key', npmFileHash);
       expect(setFailedSpy).not.toHaveBeenCalled();
     });
 
@@ -288,6 +293,7 @@ describe('run', () => {
       expect(infoSpy).toHaveBeenLastCalledWith(
         `Cache saved with the key: ${yarnFileHash}`
       );
+      expect(core.setOutput).toHaveBeenCalledWith('cache-key', yarnFileHash);
       expect(setFailedSpy).not.toHaveBeenCalled();
     });
 
@@ -297,9 +303,9 @@ describe('run', () => {
         key === State.CachePackageManager
           ? inputs['cache']
           : key === State.CacheMatchedKey
-          ? pnpmFileHash
+          ? 'no-match'
           : key === State.CachePrimaryKey
-          ? npmFileHash
+          ? pnpmFileHash
           : key === State.CachePaths
           ? '["/foo/bar"]'
           : 'not expected'
@@ -316,8 +322,9 @@ describe('run', () => {
       );
       expect(saveCacheSpy).toHaveBeenCalled();
       expect(infoSpy).toHaveBeenLastCalledWith(
-        `Cache saved with the key: ${npmFileHash}`
+        `Cache saved with the key: ${pnpmFileHash}`
       );
+      expect(core.setOutput).toHaveBeenCalledWith('cache-key', pnpmFileHash);
       expect(setFailedSpy).not.toHaveBeenCalled();
     });
 

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,8 @@ inputs:
 outputs:
   cache-hit: 
     description: 'A boolean value to indicate if a cache was hit.'
+  cache-key:
+    description: 'The key used for the cache.'
   node-version:
     description: 'The installed node version.'
 runs:

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,8 @@ outputs:
     description: 'A boolean value to indicate if a cache was hit.'
   cache-key:
     description: 'The key used for the cache.'
+  cache-matched-key:
+    description: 'The key used for the cache that resulted in a cache hit.'
   node-version:
     description: 'The installed node version.'
 runs:

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -83729,6 +83729,7 @@ const cachePackages = (packageManager) => __awaiter(void 0, void 0, void 0, func
         return;
     }
     core.info(`Cache saved with the key: ${primaryKey}`);
+    core.setOutput('cache-key', primaryKey);
 });
 run(true);
 

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -93337,6 +93337,8 @@ const restoreCache = (packageManager, cacheDependencyPath) => __awaiter(void 0, 
         cacheKey = yield cache.restoreCache(cachePaths, primaryKey);
     }
     core.setOutput('cache-hit', Boolean(cacheKey));
+    core.setOutput('cache-matched-key', cacheKey);
+    core.debug(`cache-matched-key is ${cacheKey}`);
     if (!cacheKey) {
         core.info(`${packageManager} cache is not found`);
         return;

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -93326,6 +93326,7 @@ const restoreCache = (packageManager, cacheDependencyPath) => __awaiter(void 0, 
     const primaryKey = `${keyPrefix}-${fileHash}`;
     core.debug(`primary key is ${primaryKey}`);
     core.saveState(constants_1.State.CachePrimaryKey, primaryKey);
+    core.setOutput('cache-key', primaryKey);
     const isManagedByYarnBerry = yield (0, cache_utils_1.repoHasYarnBerryManagedDependencies)(packageManagerInfo, cacheDependencyPath);
     let cacheKey;
     if (isManagedByYarnBerry) {

--- a/src/cache-restore.ts
+++ b/src/cache-restore.ts
@@ -45,6 +45,7 @@ export const restoreCache = async (
   core.debug(`primary key is ${primaryKey}`);
 
   core.saveState(State.CachePrimaryKey, primaryKey);
+  core.setOutput('cache-key', primaryKey);
 
   const isManagedByYarnBerry = await repoHasYarnBerryManagedDependencies(
     packageManagerInfo,

--- a/src/cache-restore.ts
+++ b/src/cache-restore.ts
@@ -62,6 +62,8 @@ export const restoreCache = async (
   }
 
   core.setOutput('cache-hit', Boolean(cacheKey));
+  core.setOutput('cache-matched-key', cacheKey);
+  core.debug(`cache-matched-key is ${cacheKey}`);
 
   if (!cacheKey) {
     core.info(`${packageManager} cache is not found`);

--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -66,6 +66,7 @@ const cachePackages = async (packageManager: string) => {
   }
 
   core.info(`Cache saved with the key: ${primaryKey}`);
+  core.setOutput('cache-key', primaryKey);
 };
 
 run(true);


### PR DESCRIPTION
**Description:**
Adds `cache-key` as an output

**Related issue:**
- https://github.com/actions/setup-node/issues/1129
- https://github.com/actions/setup-node/issues/1181
- https://github.com/actions/setup-node/issues/1152

**Check list:**
- [ ] Mark if documentation changes are required.
- [X] Mark if tests were added or updated to cover the changes.