### PR TITLE
Add mirror-url parameter to allow downloading Node.js from a custom URL

### DIFF
--- a/__tests__/canary-installer.test.ts
+++ b/__tests__/canary-installer.test.ts
@@ -548,11 +548,13 @@ describe('setup-node', () => {
         if (!this.mirrorURL) {
           core.info('Using mirror URL: https://nodejs.org/download/v8-canary');
           return 'https://nodejs.org/download/v8-canary';  // Default URL
+        }else{
+          if (this.mirrorURL === '' ){
+            throw new Error('Mirror URL is empty. Please provide a valid mirror URL.');
         }
-    
-        // Log and return the custom mirror URL
-        core.info(`Using mirror URL: ${this.mirrorURL}`);
         return this.mirrorURL;
+      }
+       
       }
     }
      
@@ -662,9 +664,7 @@ describe('setup-node', () => {
       // Restore the original core.info function after the test
       infoSpy.mockRestore();
     });
-    it('should throw an error if mirror URL is empty string', () => {
-      const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
-    
+    it('should throw an error if mirror URL is empty string', async () => {
       const nodeInfo: NodeInputs = {
         versionSpec: '8.0.0-canary',
         arch: 'x64',
@@ -676,13 +676,9 @@ describe('setup-node', () => {
       const canaryBuild = new CanaryBuild(nodeInfo);
     
       // Expect the method to throw an error for empty string mirror URL
-      expect(() => canaryBuild.getDistributionMirrorUrl()).toThrowError('Mirror URL is empty. Please provide a valid mirror URL.');
-    
-      // Ensure that core.info was not called because the error was thrown first
-      expect(infoSpy).not.toHaveBeenCalled();
-      
-      infoSpy.mockRestore();
+      expect(canaryBuild.getDistributionMirrorUrl()).toThrow('Mirror URL is empty. Please provide a valid mirror URL.');
     });
+   
      
    
      

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -286,9 +286,9 @@ describe('main tests', () => {
       );
     });
   });
-});
 
-// Create a mock object that satisfies the BaseDistribution interface
+
+  // Create a mock object that satisfies the BaseDistribution interface
 const createMockNodejsDistribution = () => ({
   setupNodeJs: jest.fn(),
   httpClient: {}, // Mocking the httpClient (you can replace this with more detailed mocks if needed)
@@ -328,13 +328,13 @@ describe('Mirror URL Tests', () => {
       auth: undefined,
       stable: true,
       arch: 'x64',
-      mirrorURL: 'https://custom-mirror-url.com',
+      mirrorURL: 'https://custom-mirror-url.com', // Ensure this matches
     });
   });
 
   it('should use default mirror URL when no mirror URL is provided', async () => {
     jest.spyOn(core, 'getInput').mockImplementation((name: string) => {
-      if (name === 'mirror-url') return '';
+      if (name === 'mirror-url') return ''; // Simulating no mirror URL provided
       if (name === 'node-version') return '14.x';
       return '';
     });
@@ -344,7 +344,7 @@ describe('Mirror URL Tests', () => {
 
     await main.run();
 
-    // Expect that setupNodeJs is called with an empty mirror URL
+    // Expect that setupNodeJs is called with an empty mirror URL (default behavior)
     expect(mockNodejsDistribution.setupNodeJs).toHaveBeenCalledWith(expect.objectContaining({
       mirrorURL: '', // Default URL is expected to be handled internally
     }));
@@ -360,42 +360,17 @@ describe('Mirror URL Tests', () => {
     };
   
     // Simulate calling the main function that will trigger setupNodeJs
-    await main.run({ mirrorURL });
-  
-    // Debugging: Log the arguments that setupNodeJs was called with
-    console.log('setupNodeJs calls:', mockNodejsDistribution.setupNodeJs.mock.calls);
+    await main.run();
   
     // Assert that setupNodeJs was called with the correct trimmed mirrorURL
     expect(mockNodejsDistribution.setupNodeJs).toHaveBeenCalledWith(
       expect.objectContaining({
-        mirrorURL: expectedTrimmedURL,
+        mirrorURL: expectedTrimmedURL, // Ensure the URL is trimmed properly
       })
     );
   });
-  
-  
-
-  it('should warn if architecture is provided but node-version is missing', async () => {
-    jest.spyOn(core, 'getInput').mockImplementation((name: string) => {
-      if (name === 'architecture') return 'x64';
-      if (name === 'node-version') return '';
-      return '';
-    });
-
-    const mockWarning = jest.spyOn(core, 'warning');
-    const mockNodejsDistribution = createMockNodejsDistribution();
-    (installerFactory.getNodejsDistribution as jest.Mock).mockReturnValue(mockNodejsDistribution);
-
-    await main.run();
-
-    expect(mockWarning).toHaveBeenCalledWith(
-      "`architecture` is provided but `node-version` is missing. In this configuration, the version/architecture of Node will not be changed. To fix this, provide `architecture` in combination with `node-version`"
-    );
-    
-    expect(mockNodejsDistribution.setupNodeJs).not.toHaveBeenCalled(); // Setup Node should not be called
-  });
+});
 });
 
-function someFunctionThatCallsSetupNodeJs(arg0: { mirrorURL: string; }) {
-  throw new Error('Function not implemented.');
-}
+
+

--- a/__tests__/nightly-installer.test.ts
+++ b/__tests__/nightly-installer.test.ts
@@ -679,7 +679,8 @@ describe('NightlyNodejs', () => {
       mirrorURL: '', versionSpec: '18.0.0-nightly', arch: 'x64',
       checkLatest: false,
       stable: false
-    };    const nightlyNode = new TestNightlyNodejs(nodeInfo);
+    }; 
+      const nightlyNode = new TestNightlyNodejs(nodeInfo);
 
     const distributionUrl = nightlyNode.getDistributionUrlPublic();
 
@@ -688,8 +689,12 @@ describe('NightlyNodejs', () => {
   });
 
   it('falls back to default distribution URL if mirror URL is undefined', async () => {
-    const nodeInfo: NodeInputs = { nodeVersion: '18.0.0-nightly', architecture: 'x64', platform: 'linux' };
-    const nightlyNode = new TestNightlyNodejs(nodeInfo);
+    const nodeInfo: NodeInputs = {
+      mirrorURL: '', versionSpec: '18.0.0-nightly', arch: 'x64',
+      checkLatest: false,
+      stable: false
+    }; 
+        const nightlyNode = new TestNightlyNodejs(nodeInfo);
 
     const distributionUrl = nightlyNode.getDistributionUrlPublic();
 

--- a/__tests__/rc-installer.test.ts
+++ b/__tests__/rc-installer.test.ts
@@ -453,87 +453,93 @@ describe('setup-node', () => {
       );
     });
   });
+
+ 
+  describe('RcBuild - Mirror URL functionality', () => {
+    const nodeInfo: NodeInputs = {
+      versionSpec: '18.0.0-rc',
+      arch: 'x64',
+      mirrorURL: '',
+      checkLatest: false,
+      stable: false,
+    };
+  
+    it('should return the default distribution URL if no mirror URL is provided', () => {
+      const rcBuild = new RcBuild(nodeInfo);
+  
+      const distributionUrl = rcBuild.getDistributionUrl();
+  
+      // Default URL
+      expect(distributionUrl).toBe('https://nodejs.org/download/rc');
+    });
+  
+    it('should use the mirror URL from nodeInfo if provided', () => {
+      const mirrorURL = 'https://my.custom.mirror/nodejs';  // Set the custom mirror URL
+      nodeInfo.mirrorURL = mirrorURL;  // Set the mirrorURL in nodeInfo
+      
+      const rcBuild = new RcBuild(nodeInfo);
+  
+      // Mock core.info to track its calls
+      const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
+  
+      // Call the method
+      const distributionMirrorUrl = rcBuild['getDistributionMirrorUrl'](); // Access the protected method
+  
+      // Assert that core.info was called with the correct mirror URL message
+      expect(infoSpy).toHaveBeenCalledWith(`Using mirror URL: ${mirrorURL}`);
+      
+      // Assert that the returned URL is the mirror URL
+      expect(distributionMirrorUrl).toBe(mirrorURL);
+      
+      // Restore the original core.info function after the test
+      infoSpy.mockRestore();
+    });
+  
+    it('should throw an error if mirror URL is empty', () => {
+      nodeInfo.mirrorURL = '';  // Empty mirror URL
+      
+      const rcBuild = new RcBuild(nodeInfo);
+  
+      // Mock core.info to track its calls
+      const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
+  
+      // Expect the function to return the default URL because the mirror URL is empty
+      const distributionMirrorUrl = rcBuild['getDistributionMirrorUrl']();
+  
+      expect(distributionMirrorUrl).toBe('https://nodejs.org/download/rc');
+  
+      // Ensure that core.info was NOT called because it's not a custom mirror URL
+      expect(infoSpy).not.toHaveBeenCalled();
+  
+      infoSpy.mockRestore();
+    });
+  
+    it('should throw an error if mirror URL is undefined', () => {
+      nodeInfo.mirrorURL = undefined;  // Undefined mirror URL
+      
+      const rcBuild = new RcBuild(nodeInfo);
+  
+      // Mock core.info to track its calls
+      const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
+  
+      // Expect the function to return the default URL because the mirror URL is undefined
+      const distributionMirrorUrl = rcBuild['getDistributionMirrorUrl']();
+  
+      expect(distributionMirrorUrl).toBe('https://nodejs.org/download/rc');
+  
+      // Ensure that core.info was NOT called because it's not a custom mirror URL
+      expect(infoSpy).not.toHaveBeenCalled();
+  
+      infoSpy.mockRestore();
+    });
+  });
+  
+  
+  
+  
+  
 });
 
 
 
-describe('RcBuild - Mirror URL functionality', () => {
-  const nodeInfo: NodeInputs = {
-    versionSpec: '18.0.0-rc', arch: 'x64', mirrorURL: '',
-    checkLatest: false,
-    stable: false
-  };
 
-  it('should return the default distribution URL if no mirror URL is provided', () => {
-    const rcBuild = new RcBuild(nodeInfo);
-
-    const distributionUrl = rcBuild.getDistributionUrl();
-
-    expect(distributionUrl).toBe('https://nodejs.org/download/rc');
-  });
-
-  it('should use the mirror URL from nodeInfo if provided', () => {
-    const mirrorURL = 'https://my.custom.mirror/nodejs';
-    nodeInfo.mirrorURL = mirrorURL;
-    const rcBuild = new RcBuild(nodeInfo);
-
-    // @ts-ignore: Accessing protected method for testing purposes
-    const distributionMirrorUrl = rcBuild.getDistributionMirrorUrl();
-
-    expect(core.info).toHaveBeenCalledWith(`Using mirror URL: ${mirrorURL}`);
-    expect(distributionMirrorUrl).toBe(mirrorURL);
-  });
-
-  it('should fall back to the default distribution URL if mirror URL is not provided', () => {
-    nodeInfo.mirrorURL = ''; // No mirror URL
-    const rcBuild = new RcBuild(nodeInfo);
-
- // @ts-ignore: Accessing protected method for testing purposes
- const distributionMirrorUrl = rcBuild.getDistributionMirrorUrl();
-
-    expect(core.info).toHaveBeenCalledWith(`Using mirror URL: https://nodejs.org/download/rc`);
-    expect(distributionMirrorUrl).toBe('https://nodejs.org/download/rc');
-  });
-
-  it('should log the correct info when mirror URL is not provided', () => {
-    nodeInfo.mirrorURL = ''; // No mirror URL
-    const rcBuild = new RcBuild(nodeInfo);
-
- // @ts-ignore: Accessing protected method for testing purposes
- const distributionMirrorUrl = rcBuild.getDistributionMirrorUrl();
-
-    expect(core.info).toHaveBeenCalledWith('Using mirror URL: https://nodejs.org/download/rc');
-  });
-
-  it('should throw an error if mirror URL is undefined and not provided', async () => {
-    nodeInfo.mirrorURL = undefined; // Undefined mirror URL
-    const rcBuild = new RcBuild(nodeInfo);
-
-    // @ts-ignore: Accessing protected method for testing purposes
-    await expect(rcBuild['getDistributionMirrorUrl']()).resolves.toBe('https://nodejs.org/download/rc');
-  });
-
-  it('should return mirror URL if provided in nodeInfo', () => {
-    const mirrorURL = 'https://custom.mirror.url';
-    nodeInfo.mirrorURL = mirrorURL;
-
-    const rcBuild = new RcBuild(nodeInfo);
-    // @ts-ignore: Accessing protected method for testing purposes
-        // @ts-ignore: Accessing protected method for testing purposes
-        const url = rcBuild['getDistributionMirrorUrl']();
-
-    expect(core.info).toHaveBeenCalledWith(`Using mirror URL: ${mirrorURL}`);
-    expect(url).toBe(mirrorURL);
-  });
-
-  it('should use the default URL if mirror URL is empty string', () => {
-    nodeInfo.mirrorURL = ''; // Empty string for mirror URL
-    const rcBuild = new RcBuild(nodeInfo);
-
-    // @ts-ignore: Accessing protected method for testing purposes
-    const url = rcBuild['getDistributionMirrorUrl']();
-
-    expect(core.info).toHaveBeenCalledWith('Using mirror URL: https://nodejs.org/download/rc');
-    expect(url).toBe('https://nodejs.org/download/rc');
-  });
-});

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   check-latest:
     description: 'Set this option if you want the action to check for the latest available version that satisfies the version spec.'
     default: false
+   mirrorURL:
+    description: 'Custom mirror URL to download Node.js from (optional)'
+    required: false
   registry-url:
     description: 'Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN.'
   scope:

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
   check-latest:
     description: 'Set this option if you want the action to check for the latest available version that satisfies the version spec.'
     default: false
-  mirrorURL:
+  mirror-url:
     description: 'Custom mirror URL to download Node.js from (optional)'
     required: false
   registry-url:

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
   check-latest:
     description: 'Set this option if you want the action to check for the latest available version that satisfies the version spec.'
     default: false
-   mirrorURL:
+  mirrorURL:
     description: 'Custom mirror URL to download Node.js from (optional)'
     required: false
   registry-url:

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100238,6 +100238,9 @@ class BaseDistribution {
                 exeUrl = `${initialUrl}/v${version}/win-${osArch}/node.exe`;
                 libUrl = `${initialUrl}/v${version}/win-${osArch}/node.lib`;
                 core.info(`Downloading only node binary from ${exeUrl}`);
+                if (!exeUrl) {
+                    core.error('unable to download node binary with the provided URL. Please check and try again');
+                }
                 const exePath = yield tc.downloadTool(exeUrl);
                 yield io.cp(exePath, path.join(tempDir, 'node.exe'));
                 const libPath = yield tc.downloadTool(libUrl);

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100670,6 +100670,7 @@ class OfficialBuilds extends base_distribution_1.default {
             const versions = this.filterVersions(nodeJsVersions);
             core.info('versions' + versions);
             const evaluatedVersion = this.evaluateVersions(versions);
+            core.info('eversions' + evaluatedVersion);
             if (this.nodeInfo.checkLatest) {
                 const evaluatedVersion = yield this.findVersionInDist(nodeJsVersions);
                 this.nodeInfo.versionSpec = evaluatedVersion;

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100457,6 +100457,7 @@ class NightlyNodejs extends base_distribution_prerelease_1.default {
         // Check if mirrorUrl exists in the nodeInfo and return it if available
         const mirrorUrl = this.nodeInfo.mirrorURL;
         if (mirrorUrl) {
+            core.info(`Downloding Using mirror URL: ${mirrorUrl}`);
             return mirrorUrl;
         }
         // Default to the official Node.js nightly distribution URL if no mirror URL is provided

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100215,6 +100215,11 @@ class BaseDistribution {
                     this.osPlat == 'win32') {
                     return yield this.acquireWindowsNodeFromFallbackLocation(info.resolvedVersion, info.arch, info.downloadUrl);
                 }
+                // Handle network-related issues (e.g., DNS resolution failures)
+                if (err instanceof Error && err.message.includes('getaddrinfo EAI_AGAIN')) {
+                    core.error(`Network error: Failed to resolve the server at ${info.downloadUrl}. 
+            This could be due to a DNS resolution issue. Please verify the URL or check your network connection.`);
+                }
                 core.error(`Download failed from ${info.downloadUrl}. Please check the URl and try again.`);
                 throw err;
             }

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100436,55 +100436,33 @@ exports.getNodejsDistribution = getNodejsDistribution;
 
 "use strict";
 
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const base_distribution_prerelease_1 = __importDefault(__nccwpck_require__(957));
-const core = __importStar(__nccwpck_require__(2186));
 class NightlyNodejs extends base_distribution_prerelease_1.default {
     constructor(nodeInfo) {
         super(nodeInfo);
         this.distribution = 'nightly';
     }
-    getDistributionMirrorUrl() {
-        // Implement the method to return the mirror URL or an empty string if not available
-        return this.nodeInfo.mirrorURL || '';
-    }
-    // Updated getDistributionUrl method to handle mirror URL or fallback
     getDistributionUrl() {
-        // Check if mirrorUrl exists in the nodeInfo and return it if available
-        const mirrorUrl = this.nodeInfo.mirrorURL;
-        if (mirrorUrl) {
-            core.info(`Downloding Using mirror URL: ${mirrorUrl}`);
-            return mirrorUrl;
+        if (this.nodeInfo.mirrorURL) {
+            if (this.nodeInfo.mirrorURL != '') {
+                return this.nodeInfo.mirrorURL;
+            }
+            else {
+                if (this.nodeInfo.mirrorURL === '') {
+                    throw new Error('Mirror URL is empty. Please provide a valid mirror URL.');
+                }
+                else {
+                    throw new Error('Mirror URL is not a valid');
+                }
+            }
         }
-        // Default to the official Node.js nightly distribution URL if no mirror URL is provided
-        core.info('Using default distribution URL for nightly Node.js.');
-        return 'https://nodejs.org/download/nightly';
+        else {
+            return 'https://nodejs.org/download/nightly';
+        }
     }
 }
 exports["default"] = NightlyNodejs;
@@ -100545,6 +100523,9 @@ class OfficialBuilds extends base_distribution_1.default {
         return __awaiter(this, void 0, void 0, function* () {
             var _a, _b;
             if (this.nodeInfo.mirrorURL) {
+                if (this.nodeInfo.mirrorURL === '') {
+                    throw new Error('Mirror URL is empty. Please provide a valid mirror URL.');
+                }
                 let downloadPath = '';
                 let toolPath = '';
                 try {
@@ -100777,51 +100758,35 @@ exports["default"] = OfficialBuilds;
 
 "use strict";
 
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const base_distribution_1 = __importDefault(__nccwpck_require__(7));
-const core = __importStar(__nccwpck_require__(2186));
 class RcBuild extends base_distribution_1.default {
+    getDistributionMirrorUrl() {
+        throw new Error('Method not implemented.');
+    }
     constructor(nodeInfo) {
         super(nodeInfo);
     }
     getDistributionUrl() {
-        return 'https://nodejs.org/download/rc';
-    }
-    getDistributionMirrorUrl() {
-        // Check if mirrorUrl exists in the nodeInfo and return it if available
-        const mirrorUrl = this.nodeInfo.mirrorURL;
-        if (mirrorUrl) {
-            core.info(`Using mirror URL: ${mirrorUrl}`);
-            return mirrorUrl;
+        if (this.nodeInfo.mirrorURL) {
+            if (this.nodeInfo.mirrorURL != '') {
+                return this.nodeInfo.mirrorURL;
+            }
+            else {
+                if (this.nodeInfo.mirrorURL === '') {
+                    throw new Error('Mirror URL is empty. Please provide a valid mirror URL.');
+                }
+                else {
+                    throw new Error('Mirror URL is not a valid');
+                }
+            }
         }
-        // Return the default URL if no mirror URL is provided
-        return this.getDistributionUrl();
+        else {
+            return 'https://nodejs.org/download/rc';
+        }
     }
 }
 exports["default"] = RcBuild;
@@ -100834,54 +100799,33 @@ exports["default"] = RcBuild;
 
 "use strict";
 
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const base_distribution_prerelease_1 = __importDefault(__nccwpck_require__(957));
-const core = __importStar(__nccwpck_require__(2186));
 class CanaryBuild extends base_distribution_prerelease_1.default {
-    static getDistributionMirrorUrl() {
-        throw new Error('Method not implemented.');
-    }
     constructor(nodeInfo) {
         super(nodeInfo);
         this.distribution = 'v8-canary';
     }
     getDistributionUrl() {
-        return 'https://nodejs.org/download/v8-canary';
-    }
-    getDistributionMirrorUrl() {
-        // Check if mirrorUrl exists in the nodeInfo and return it if available
-        const mirrorUrl = this.nodeInfo.mirrorURL;
-        if (mirrorUrl) {
-            core.info(`Using mirror URL: ${mirrorUrl}`);
-            return mirrorUrl;
+        if (this.nodeInfo.mirrorURL) {
+            if (this.nodeInfo.mirrorURL != '') {
+                return this.nodeInfo.mirrorURL;
+            }
+            else {
+                if (this.nodeInfo.mirrorURL === '') {
+                    throw new Error('Mirror URL is empty. Please provide a valid mirror URL.');
+                }
+                else {
+                    throw new Error('Mirror URL is not a valid');
+                }
+            }
         }
-        return 'https://nodejs.org/download/v8-canary';
+        else {
+            return 'https://nodejs.org/download/v8-canary';
+        }
     }
 }
 exports["default"] = CanaryBuild;

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100157,9 +100157,7 @@ class BaseDistribution {
     getMirrorUrlVersions() {
         return __awaiter(this, void 0, void 0, function* () {
             const initialUrl = this.getDistributionMirrorUrl();
-            core.info('initialUrl from getDistributionMirrorUrl ' + initialUrl);
             const dataUrl = `${initialUrl}/index.json`;
-            core.info('dataUrl from index ' + dataUrl);
             const response = yield this.httpClient.getJson(dataUrl);
             return response.result || [];
         });
@@ -100186,9 +100184,7 @@ class BaseDistribution {
     }
     getNodejsMirrorURLInfo(version) {
         const mirrorURL = this.nodeInfo.mirrorURL;
-        core.info('mirrorURL from getNodejsMirrorURLInfo ' + mirrorURL);
         const osArch = this.translateArchToDistUrl(this.nodeInfo.arch);
-        core.info('osArch from translateArchToDistUrl ' + osArch);
         version = semver_1.default.clean(version) || '';
         const fileName = this.osPlat == 'win32'
             ? `node-v${version}-win-${osArch}`
@@ -100199,7 +100195,6 @@ class BaseDistribution {
                 : `${fileName}.7z`
             : `${fileName}.tar.gz`;
         const url = `${mirrorURL}/v${version}/${urlFileName}`;
-        core.info('url from construct ' + url);
         return {
             downloadUrl: url,
             resolvedVersion: version,
@@ -100729,19 +100724,14 @@ class OfficialBuilds extends base_distribution_1.default {
     downloadFromMirrorURL() {
         return __awaiter(this, void 0, void 0, function* () {
             const nodeJsVersions = yield this.getMirrorUrlVersions();
-            core.info('nodeJsVersions from getMirrorUrVersions ' + nodeJsVersions);
             const versions = this.filterVersions(nodeJsVersions);
-            core.info('versions from filterVersions ' + versions);
             const evaluatedVersion = this.evaluateVersions(versions);
-            core.info('evaluatedVersion from evaluatedVersions ' + evaluatedVersion);
             if (!evaluatedVersion) {
                 throw new Error(`Unable to find Node version '${this.nodeInfo.versionSpec}' for platform ${this.osPlat} and architecture ${this.nodeInfo.arch}.`);
             }
             const toolName = this.getNodejsMirrorURLInfo(evaluatedVersion);
-            core.info('toolName from getNodejsMirrorURLInfo ' + toolName);
             try {
                 const toolPath = yield this.downloadNodejs(toolName);
-                core.info('toolPath from downloadNodejs ' + toolPath);
                 return toolPath;
             }
             catch (error) {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100154,10 +100154,12 @@ class BaseDistribution {
             return response.result || [];
         });
     }
-    getMirrorUrVersions() {
+    getMirrorUrlVersions() {
         return __awaiter(this, void 0, void 0, function* () {
             const initialUrl = this.getDistributionMirrorUrl();
+            core.info('initialUrl from getDistributionMirrorUrl ' + initialUrl);
             const dataUrl = `${initialUrl}/index.json`;
+            core.info('dataUrl from index ' + dataUrl);
             const response = yield this.httpClient.getJson(dataUrl);
             return response.result || [];
         });
@@ -100726,7 +100728,7 @@ class OfficialBuilds extends base_distribution_1.default {
     }
     downloadFromMirrorURL() {
         return __awaiter(this, void 0, void 0, function* () {
-            const nodeJsVersions = yield this.getMirrorUrVersions();
+            const nodeJsVersions = yield this.getMirrorUrlVersions();
             core.info('nodeJsVersions from getMirrorUrVersions ' + nodeJsVersions);
             const versions = this.filterVersions(nodeJsVersions);
             core.info('versions from filterVersions ' + versions);

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100651,10 +100651,7 @@ class OfficialBuilds extends base_distribution_1.default {
     }
     getDistributionMirrorUrl() {
         const mirrorURL = this.nodeInfo.mirrorURL;
-        if (!mirrorURL) {
-            throw new Error('Mirror URL is undefined');
-        }
-        return mirrorURL;
+        return mirrorURL !== null && mirrorURL !== void 0 ? mirrorURL : '';
     }
     getManifest() {
         core.debug('Getting manifest from actions/node-versions@main');

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100457,7 +100457,7 @@ class NightlyNodejs extends base_distribution_prerelease_1.default {
         // Check if mirrorUrl exists in the nodeInfo and return it if available
         const mirrorUrl = this.nodeInfo.mirrorURL;
         if (mirrorUrl) {
-            core.info(`Using mirror URL: ${mirrorUrl}`);
+            core.info(`Downloding Using mirror URL: ${mirrorUrl}`);
             return mirrorUrl;
         }
         // Default to the official Node.js nightly distribution URL if no mirror URL is provided

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100207,6 +100207,7 @@ class BaseDistribution {
                     this.osPlat == 'win32') {
                     return yield this.acquireWindowsNodeFromFallbackLocation(info.resolvedVersion, info.arch);
                 }
+                core.error(`Download failed from ${info.downloadUrl}. Please check the URl and try again.`);
                 throw err;
             }
             const toolPath = yield this.extractArchive(downloadPath, info, true);

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100728,7 +100728,7 @@ class OfficialBuilds extends base_distribution_1.default {
             const versions = this.filterVersions(nodeJsVersions);
             const evaluatedVersion = this.evaluateVersions(versions);
             if (!evaluatedVersion) {
-                throw new Error(`Unable to find Node version '${this.nodeInfo.versionSpec}' for platform ${this.osPlat} and architecture ${this.nodeInfo.arch}.`);
+                throw new Error(`Unable to find Node version '${this.nodeInfo.versionSpec}' for platform ${this.osPlat} and architecture ${this.nodeInfo.arch} from the provided ${this.nodeInfo.mirrorURL}.`);
             }
             const toolName = this.getNodejsMirrorURLInfo(evaluatedVersion);
             try {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100728,7 +100728,7 @@ class OfficialBuilds extends base_distribution_1.default {
             const versions = this.filterVersions(nodeJsVersions);
             const evaluatedVersion = this.evaluateVersions(versions);
             if (!evaluatedVersion) {
-                throw new Error(`Unable to find Node version '${this.nodeInfo.versionSpec}' for platform ${this.osPlat} and architecture ${this.nodeInfo.arch} from the provided ${this.nodeInfo.mirrorURL}.`);
+                throw new Error(`Unable to find Node version '${this.nodeInfo.versionSpec}' for platform ${this.osPlat} and architecture ${this.nodeInfo.arch} from the provided mirror-url ${this.nodeInfo.mirrorURL}. Please check the mirror-url`);
             }
             const toolName = this.getNodejsMirrorURLInfo(evaluatedVersion);
             try {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100864,6 +100864,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 const base_distribution_prerelease_1 = __importDefault(__nccwpck_require__(957));
 const core = __importStar(__nccwpck_require__(2186));
 class CanaryBuild extends base_distribution_prerelease_1.default {
+    static getDistributionMirrorUrl() {
+        throw new Error('Method not implemented.');
+    }
     constructor(nodeInfo) {
         super(nodeInfo);
         this.distribution = 'v8-canary';

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100666,11 +100666,14 @@ class OfficialBuilds extends base_distribution_1.default {
     downloadFromMirrorURL() {
         return __awaiter(this, void 0, void 0, function* () {
             const nodeJsVersions = yield this.getNodeJsVersions();
+            core.info('versions from nodeJSVersions' + nodeJsVersions);
             const versions = this.filterVersions(nodeJsVersions);
+            core.info('versions' + versions);
             const evaluatedVersion = this.evaluateVersions(versions);
             if (this.nodeInfo.checkLatest) {
                 const evaluatedVersion = yield this.findVersionInDist(nodeJsVersions);
                 this.nodeInfo.versionSpec = evaluatedVersion;
+                core.info('versionSpec' + this.nodeInfo.versionSpec);
             }
             if (!evaluatedVersion) {
                 throw new Error(`Unable to find Node version '${this.nodeInfo.versionSpec}' for platform ${this.osPlat} and architecture ${this.nodeInfo.arch}.`);

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100158,8 +100158,25 @@ class BaseDistribution {
         return __awaiter(this, void 0, void 0, function* () {
             const initialUrl = this.getDistributionUrl();
             const dataUrl = `${initialUrl}/index.json`;
-            const response = yield this.httpClient.getJson(dataUrl);
-            return response.result || [];
+            try {
+                const response = yield this.httpClient.getJson(dataUrl);
+                return response.result || [];
+            }
+            catch (err) {
+                if (err instanceof Error && err.message.includes('getaddrinfo EAI_AGAIN')) {
+                    core.error(`Network error: Failed to resolve the server at ${dataUrl}. 
+                      Please check your DNS settings or verify that the URL is correct.`);
+                }
+                else if (err instanceof hc.HttpClientError && err.statusCode === 404) {
+                    core.error(`404 Error: Unable to find versions at ${dataUrl}. 
+                      Please verify that the mirror URL is valid.`);
+                }
+                else {
+                    core.error(`Failed to fetch Node.js versions from ${dataUrl}. 
+                      Please check the URL and try again.}`);
+                }
+                throw err;
+            }
         });
     }
     getNodejsDistInfo(version) {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100686,9 +100686,13 @@ class OfficialBuilds extends base_distribution_1.default {
             }
             catch (error) {
                 if (error instanceof tc.HTTPError && error.httpStatusCode === 404) {
-                    core.warning(`Node version ${this.nodeInfo.versionSpec} for platform ${this.osPlat} and architecture ${this.nodeInfo.arch} was found but failed to download. ` +
+                    core.error(`Node version ${this.nodeInfo.versionSpec} for platform ${this.osPlat} and architecture ${this.nodeInfo.arch} was found but failed to download. ` +
                         'This usually happens when downloadable binaries are not fully updated at https://nodejs.org/. ' +
                         'To resolve this issue you may either fall back to the older version or try again later.');
+                }
+                else {
+                    // For any other error type, you can log the error message.
+                    core.error(`An unexpected error occurred like url might not correct`);
                 }
                 throw error;
             }

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100205,7 +100205,7 @@ class BaseDistribution {
                 if (err instanceof tc.HTTPError &&
                     err.httpStatusCode == 404 &&
                     this.osPlat == 'win32') {
-                    return yield this.acquireWindowsNodeFromFallbackLocation(info.resolvedVersion, info.arch);
+                    return yield this.acquireWindowsNodeFromFallbackLocation(info.resolvedVersion, info.arch, info.downloadUrl);
                 }
                 core.error(`Download failed from ${info.downloadUrl}. Please check the URl and try again.`);
                 throw err;
@@ -100223,7 +100223,7 @@ class BaseDistribution {
         return { range: valid, options };
     }
     acquireWindowsNodeFromFallbackLocation(version_1) {
-        return __awaiter(this, arguments, void 0, function* (version, arch = os_1.default.arch()) {
+        return __awaiter(this, arguments, void 0, function* (version, arch = os_1.default.arch(), downloadUrl) {
             const initialUrl = this.getDistributionUrl();
             core.info('url: ' + initialUrl);
             const osArch = this.translateArchToDistUrl(arch);
@@ -100239,7 +100239,7 @@ class BaseDistribution {
                 exeUrl = `${initialUrl}/v${version}/win-${osArch}/node.exe`;
                 libUrl = `${initialUrl}/v${version}/win-${osArch}/node.lib`;
                 core.info(`Downloading only node binary from ${exeUrl}`);
-                if (!exeUrl) {
+                if (downloadUrl != exeUrl) {
                     core.error('unable to download node binary with the provided URL. Please check and try again');
                 }
                 const exePath = yield tc.downloadTool(exeUrl);

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100156,7 +100156,7 @@ class BaseDistribution {
     }
     getMirrorUrlVersions() {
         return __awaiter(this, void 0, void 0, function* () {
-            const initialUrl = this.getDistributionMirrorUrl();
+            const initialUrl = this.getDistributionUrl();
             const dataUrl = `${initialUrl}/index.json`;
             const response = yield this.httpClient.getJson(dataUrl);
             return response.result || [];
@@ -100173,7 +100173,7 @@ class BaseDistribution {
                 ? `${fileName}.zip`
                 : `${fileName}.7z`
             : `${fileName}.tar.gz`;
-        const initialUrl = this.getDistributionMirrorUrl();
+        const initialUrl = this.getDistributionUrl();
         const url = `${initialUrl}/v${version}/${urlFileName}`;
         return {
             downloadUrl: url,
@@ -100647,11 +100647,10 @@ class OfficialBuilds extends base_distribution_1.default {
         return version;
     }
     getDistributionUrl() {
+        if (this.nodeInfo.mirrorURL) {
+            return this.nodeInfo.mirrorURL;
+        }
         return `https://nodejs.org/dist`;
-    }
-    getDistributionMirrorUrl() {
-        const mirrorURL = this.nodeInfo.mirrorURL;
-        return mirrorURL !== null && mirrorURL !== void 0 ? mirrorURL : '';
     }
     getManifest() {
         core.debug('Getting manifest from actions/node-versions@main');

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100670,7 +100670,7 @@ class OfficialBuilds extends base_distribution_1.default {
             const versions = this.filterVersions(nodeJsVersions);
             core.info('versions' + versions);
             const evaluatedVersion = this.evaluateVersions(versions);
-            core.info('eversions' + evaluatedVersion);
+            core.info('versionSpec' + this.nodeInfo.versionSpec);
             if (this.nodeInfo.checkLatest) {
                 const evaluatedVersion = yield this.findVersionInDist(nodeJsVersions);
                 this.nodeInfo.versionSpec = evaluatedVersion;

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100668,6 +100668,10 @@ class OfficialBuilds extends base_distribution_1.default {
             const nodeJsVersions = yield this.getNodeJsVersions();
             const versions = this.filterVersions(nodeJsVersions);
             const evaluatedVersion = this.evaluateVersions(versions);
+            if (this.nodeInfo.checkLatest) {
+                const evaluatedVersion = yield this.findVersionInDist(nodeJsVersions);
+                this.nodeInfo.versionSpec = evaluatedVersion;
+            }
             if (!evaluatedVersion) {
                 throw new Error(`Unable to find Node version '${this.nodeInfo.versionSpec}' for platform ${this.osPlat} and architecture ${this.nodeInfo.arch}.`);
             }
@@ -100808,7 +100812,7 @@ function run() {
             if (!arch) {
                 arch = os_1.default.arch();
             }
-            const mirrorURL = core.getInput('mirrorURL').trim(); // .trim() to remove any accidental spaces
+            const mirrorURL = core.getInput('mirror-url').trim(); // .trim() to remove any accidental spaces
             if (version) {
                 const token = core.getInput('token');
                 const auth = !token ? undefined : `token ${token}`;

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100225,6 +100225,7 @@ class BaseDistribution {
     acquireWindowsNodeFromFallbackLocation(version_1) {
         return __awaiter(this, arguments, void 0, function* (version, arch = os_1.default.arch()) {
             const initialUrl = this.getDistributionUrl();
+            core.info('url: ' + initialUrl);
             const osArch = this.translateArchToDistUrl(arch);
             // Create temporary folder to download to
             const tempDownloadFolder = `temp_${(0, uuid_1.v4)()}`;

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100184,7 +100184,9 @@ class BaseDistribution {
     }
     getNodejsMirrorURLInfo(version) {
         const mirrorURL = this.nodeInfo.mirrorURL;
+        core.info('mirrorURL from getNodejsMirrorURLInfo ' + mirrorURL);
         const osArch = this.translateArchToDistUrl(this.nodeInfo.arch);
+        core.info('osArch from translateArchToDistUrl ' + osArch);
         version = semver_1.default.clean(version) || '';
         const fileName = this.osPlat == 'win32'
             ? `node-v${version}-win-${osArch}`
@@ -100195,6 +100197,7 @@ class BaseDistribution {
                 : `${fileName}.7z`
             : `${fileName}.tar.gz`;
         const url = `${mirrorURL}/v${version}/${urlFileName}`;
+        core.info('url from construct ' + url);
         return {
             downloadUrl: url,
             resolvedVersion: version,
@@ -100528,6 +100531,7 @@ class OfficialBuilds extends base_distribution_1.default {
                 try {
                     core.info(`Attempting to download using mirror URL...`);
                     downloadPath = yield this.downloadFromMirrorURL(); // Attempt to download from the mirror
+                    core.info('downloadPath from downloadFromMirrorURL() ' + downloadPath);
                     if (downloadPath) {
                         toolPath = downloadPath;
                     }
@@ -100723,14 +100727,19 @@ class OfficialBuilds extends base_distribution_1.default {
     downloadFromMirrorURL() {
         return __awaiter(this, void 0, void 0, function* () {
             const nodeJsVersions = yield this.getMirrorUrVersions();
+            core.info('nodeJsVersions from getMirrorUrVersions ' + nodeJsVersions);
             const versions = this.filterVersions(nodeJsVersions);
+            core.info('versions from filterVersions ' + versions);
             const evaluatedVersion = this.evaluateVersions(versions);
+            core.info('evaluatedVersion from evaluatedVersions ' + evaluatedVersion);
             if (!evaluatedVersion) {
                 throw new Error(`Unable to find Node version '${this.nodeInfo.versionSpec}' for platform ${this.osPlat} and architecture ${this.nodeInfo.arch}.`);
             }
             const toolName = this.getNodejsMirrorURLInfo(evaluatedVersion);
+            core.info('toolName from getNodejsMirrorURLInfo ' + toolName);
             try {
                 const toolPath = yield this.downloadNodejs(toolName);
+                core.info('toolPath from downloadNodejs ' + toolPath);
                 return toolPath;
             }
             catch (error) {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100457,7 +100457,6 @@ class NightlyNodejs extends base_distribution_prerelease_1.default {
         // Check if mirrorUrl exists in the nodeInfo and return it if available
         const mirrorUrl = this.nodeInfo.mirrorURL;
         if (mirrorUrl) {
-            core.info(`Downloding Using mirror URL: ${mirrorUrl}`);
             return mirrorUrl;
         }
         // Default to the official Node.js nightly distribution URL if no mirror URL is provided

--- a/src/distributions/base-distribution.ts
+++ b/src/distributions/base-distribution.ts
@@ -105,9 +105,12 @@ export default abstract class BaseDistribution {
     return response.result || [];
   }
 
-  protected async getMirrorUrVersions(): Promise<INodeVersion[]> {
+  protected async getMirrorUrlVersions(): Promise<INodeVersion[]> {
     const initialUrl = this.getDistributionMirrorUrl();
+    core.info('initialUrl from getDistributionMirrorUrl '+initialUrl);
+    
     const dataUrl = `${initialUrl}/index.json`;
+    core.info('dataUrl from index '+dataUrl);
 
     const response = await this.httpClient.getJson<INodeVersion[]>(dataUrl);
     return response.result || [];

--- a/src/distributions/base-distribution.ts
+++ b/src/distributions/base-distribution.ts
@@ -169,7 +169,8 @@ export default abstract class BaseDistribution {
       ) {
         return await this.acquireWindowsNodeFromFallbackLocation(
           info.resolvedVersion,
-          info.arch
+          info.arch,
+          info.downloadUrl
         );
       }
       core.error(`Download failed from ${info.downloadUrl}. Please check the URl and try again.`);
@@ -193,11 +194,12 @@ export default abstract class BaseDistribution {
 
   protected async acquireWindowsNodeFromFallbackLocation(
     version: string,
-    arch: string = os.arch()
+    arch: string = os.arch(),
+    downloadUrl : string
   ): Promise<string> {
     const initialUrl = this.getDistributionUrl();
     core.info('url: ' + initialUrl);
-        const osArch: string = this.translateArchToDistUrl(arch);
+    const osArch: string = this.translateArchToDistUrl(arch);
 
     // Create temporary folder to download to
     const tempDownloadFolder = `temp_${uuidv4()}`;
@@ -212,7 +214,7 @@ export default abstract class BaseDistribution {
       libUrl = `${initialUrl}/v${version}/win-${osArch}/node.lib`;
 
       core.info(`Downloading only node binary from ${exeUrl}`);
-      if(!exeUrl ){core.error('unable to download node binary with the provided URL. Please check and try again');}
+      if(downloadUrl != exeUrl ){core.error('unable to download node binary with the provided URL. Please check and try again');}
       
 
       const exePath = await tc.downloadTool(exeUrl);

--- a/src/distributions/base-distribution.ts
+++ b/src/distributions/base-distribution.ts
@@ -139,7 +139,11 @@ export default abstract class BaseDistribution {
 
   protected getNodejsMirrorURLInfo(version: string) {
     const mirrorURL = this.nodeInfo.mirrorURL;
+    core.info('mirrorURL from getNodejsMirrorURLInfo '+mirrorURL);
+    
     const osArch: string = this.translateArchToDistUrl(this.nodeInfo.arch);
+    core.info('osArch from translateArchToDistUrl '+osArch);
+    
     version = semver.clean(version) || '';
     const fileName: string =
       this.osPlat == 'win32'
@@ -153,6 +157,7 @@ export default abstract class BaseDistribution {
         : `${fileName}.tar.gz`;
 
     const url = `${mirrorURL}/v${version}/${urlFileName}`;
+      core.info('url from construct '+url);
 
     return <INodeVersionInfo>{
       downloadUrl: url,

--- a/src/distributions/base-distribution.ts
+++ b/src/distributions/base-distribution.ts
@@ -183,6 +183,13 @@ export default abstract class BaseDistribution {
           info.downloadUrl
         );
       }
+      // Handle network-related issues (e.g., DNS resolution failures)
+      if (err instanceof Error && err.message.includes('getaddrinfo EAI_AGAIN')) {
+        core.error(
+            `Network error: Failed to resolve the server at ${info.downloadUrl}. 
+            This could be due to a DNS resolution issue. Please verify the URL or check your network connection.`
+        );
+    }
       core.error(
         `Download failed from ${info.downloadUrl}. Please check the URl and try again.`
       );

--- a/src/distributions/base-distribution.ts
+++ b/src/distributions/base-distribution.ts
@@ -25,6 +25,7 @@ export default abstract class BaseDistribution {
   }
 
   protected abstract getDistributionUrl(): string;
+  
 
   public async setupNodeJs() {
     let nodeJsVersions: INodeVersion[] | undefined;
@@ -119,6 +120,31 @@ export default abstract class BaseDistribution {
         : `${fileName}.tar.gz`;
     const initialUrl = this.getDistributionUrl();
     const url = `${initialUrl}/v${version}/${urlFileName}`;
+
+    return <INodeVersionInfo>{
+      downloadUrl: url,
+      resolvedVersion: version,
+      arch: osArch,
+      fileName: fileName
+    };
+  }
+
+  protected getNodejsMirrorURLInfo(version: string) {
+    const mirrorURL = this.nodeInfo.mirrorURL;
+    const osArch: string = this.translateArchToDistUrl(this.nodeInfo.arch);
+    version = semver.clean(version) || '';
+    const fileName: string =
+      this.osPlat == 'win32'
+        ? `node-v${version}-win-${osArch}`
+        : `node-v${version}-${this.osPlat}-${osArch}`;
+    const urlFileName: string =
+      this.osPlat == 'win32'
+        ? this.nodeInfo.arch === 'arm64'
+          ? `${fileName}.zip`
+          : `${fileName}.7z`
+        : `${fileName}.tar.gz`;
+    
+    const url = `${mirrorURL}/v${version}/${urlFileName}`;
 
     return <INodeVersionInfo>{
       downloadUrl: url,

--- a/src/distributions/base-distribution.ts
+++ b/src/distributions/base-distribution.ts
@@ -172,6 +172,7 @@ export default abstract class BaseDistribution {
           info.arch
         );
       }
+      core.error(`Download failed from ${info.downloadUrl}. Please check the URl and try again.`);
 
       throw err;
     }

--- a/src/distributions/base-distribution.ts
+++ b/src/distributions/base-distribution.ts
@@ -25,7 +25,6 @@ export default abstract class BaseDistribution {
   }
 
   protected abstract getDistributionUrl(): string;
-  protected abstract getDistributionMirrorUrl(): string;
 
   public async setupNodeJs() {
     let nodeJsVersions: INodeVersion[] | undefined;
@@ -106,7 +105,7 @@ export default abstract class BaseDistribution {
   }
 
   protected async getMirrorUrlVersions(): Promise<INodeVersion[]> {
-    const initialUrl = this.getDistributionMirrorUrl();
+    const initialUrl = this.getDistributionUrl();
     
     const dataUrl = `${initialUrl}/index.json`;
 
@@ -127,7 +126,7 @@ export default abstract class BaseDistribution {
           ? `${fileName}.zip`
           : `${fileName}.7z`
         : `${fileName}.tar.gz`;
-    const initialUrl = this.getDistributionMirrorUrl();
+    const initialUrl = this.getDistributionUrl();
     const url = `${initialUrl}/v${version}/${urlFileName}`;
 
     return <INodeVersionInfo>{

--- a/src/distributions/base-distribution.ts
+++ b/src/distributions/base-distribution.ts
@@ -108,9 +108,22 @@ export default abstract class BaseDistribution {
     const initialUrl = this.getDistributionUrl();
     
     const dataUrl = `${initialUrl}/index.json`;
-
+    try {
     const response = await this.httpClient.getJson<INodeVersion[]>(dataUrl);
     return response.result || [];
+    }catch (err) {
+      if (err instanceof Error && err.message.includes('getaddrinfo EAI_AGAIN')) {
+          core.error(`Network error: Failed to resolve the server at ${dataUrl}. 
+                      Please check your DNS settings or verify that the URL is correct.`);
+      } else if (err instanceof hc.HttpClientError && err.statusCode === 404) {
+          core.error(`404 Error: Unable to find versions at ${dataUrl}. 
+                      Please verify that the mirror URL is valid.`);
+      } else {
+          core.error(`Failed to fetch Node.js versions from ${dataUrl}. 
+                      Please check the URL and try again.}`);
+      }
+      throw err;  
+  }
   }
 
   protected getNodejsDistInfo(version: string) {

--- a/src/distributions/base-distribution.ts
+++ b/src/distributions/base-distribution.ts
@@ -107,10 +107,8 @@ export default abstract class BaseDistribution {
 
   protected async getMirrorUrlVersions(): Promise<INodeVersion[]> {
     const initialUrl = this.getDistributionMirrorUrl();
-    core.info('initialUrl from getDistributionMirrorUrl '+initialUrl);
     
     const dataUrl = `${initialUrl}/index.json`;
-    core.info('dataUrl from index '+dataUrl);
 
     const response = await this.httpClient.getJson<INodeVersion[]>(dataUrl);
     return response.result || [];
@@ -142,10 +140,8 @@ export default abstract class BaseDistribution {
 
   protected getNodejsMirrorURLInfo(version: string) {
     const mirrorURL = this.nodeInfo.mirrorURL;
-    core.info('mirrorURL from getNodejsMirrorURLInfo '+mirrorURL);
     
     const osArch: string = this.translateArchToDistUrl(this.nodeInfo.arch);
-    core.info('osArch from translateArchToDistUrl '+osArch);
     
     version = semver.clean(version) || '';
     const fileName: string =
@@ -160,7 +156,6 @@ export default abstract class BaseDistribution {
         : `${fileName}.tar.gz`;
 
     const url = `${mirrorURL}/v${version}/${urlFileName}`;
-      core.info('url from construct '+url);
 
     return <INodeVersionInfo>{
       downloadUrl: url,

--- a/src/distributions/base-distribution.ts
+++ b/src/distributions/base-distribution.ts
@@ -211,6 +211,8 @@ export default abstract class BaseDistribution {
       libUrl = `${initialUrl}/v${version}/win-${osArch}/node.lib`;
 
       core.info(`Downloading only node binary from ${exeUrl}`);
+      if(!exeUrl ){core.error('unable to download node binary with the provided URL. Please check and try again');}
+      
 
       const exePath = await tc.downloadTool(exeUrl);
       await io.cp(exePath, path.join(tempDir, 'node.exe'));

--- a/src/distributions/base-distribution.ts
+++ b/src/distributions/base-distribution.ts
@@ -196,7 +196,8 @@ export default abstract class BaseDistribution {
     arch: string = os.arch()
   ): Promise<string> {
     const initialUrl = this.getDistributionUrl();
-    const osArch: string = this.translateArchToDistUrl(arch);
+    core.info('url: ' + initialUrl);
+        const osArch: string = this.translateArchToDistUrl(arch);
 
     // Create temporary folder to download to
     const tempDownloadFolder = `temp_${uuidv4()}`;

--- a/src/distributions/base-models.ts
+++ b/src/distributions/base-models.ts
@@ -4,7 +4,7 @@ export interface NodeInputs {
   auth?: string;
   checkLatest: boolean;
   stable: boolean;
-  mirrorURL: string;
+  mirrorURL?: string;
 }
 
 export interface INodeVersionInfo {
@@ -12,7 +12,6 @@ export interface INodeVersionInfo {
   resolvedVersion: string;
   arch: string;
   fileName: string;
-  
 }
 
 export interface INodeVersion {

--- a/src/distributions/base-models.ts
+++ b/src/distributions/base-models.ts
@@ -4,6 +4,7 @@ export interface NodeInputs {
   auth?: string;
   checkLatest: boolean;
   stable: boolean;
+  mirrorURL: string;
 }
 
 export interface INodeVersionInfo {
@@ -11,6 +12,7 @@ export interface INodeVersionInfo {
   resolvedVersion: string;
   arch: string;
   fileName: string;
+  
 }
 
 export interface INodeVersion {

--- a/src/distributions/nightly/nightly_builds.ts
+++ b/src/distributions/nightly/nightly_builds.ts
@@ -1,13 +1,31 @@
 import BasePrereleaseNodejs from '../base-distribution-prerelease';
 import {NodeInputs} from '../base-models';
+import * as core from '@actions/core';
 
 export default class NightlyNodejs extends BasePrereleaseNodejs {
+  
   protected distribution = 'nightly';
+
   constructor(nodeInfo: NodeInputs) {
     super(nodeInfo);
   }
 
+  protected getDistributionMirrorUrl(): string {
+    // Implement the method to return the mirror URL or an empty string if not available
+    return this.nodeInfo.mirrorURL || '';
+  }
+
+  // Updated getDistributionUrl method to handle mirror URL or fallback
   protected getDistributionUrl(): string {
+    // Check if mirrorUrl exists in the nodeInfo and return it if available
+    const mirrorUrl = this.nodeInfo.mirrorURL;
+    if (mirrorUrl) {
+      core.info(`Using mirror URL: ${mirrorUrl}`);
+      return mirrorUrl;
+    }
+
+    // Default to the official Node.js nightly distribution URL if no mirror URL is provided
+    core.info('Using default distribution URL for nightly Node.js.');
     return 'https://nodejs.org/download/nightly';
   }
 }

--- a/src/distributions/nightly/nightly_builds.ts
+++ b/src/distributions/nightly/nightly_builds.ts
@@ -10,22 +10,22 @@ export default class NightlyNodejs extends BasePrereleaseNodejs {
     super(nodeInfo);
   }
 
-  protected getDistributionMirrorUrl(): string {
-    // Implement the method to return the mirror URL or an empty string if not available
-    return this.nodeInfo.mirrorURL || '';
-  }
-
-  // Updated getDistributionUrl method to handle mirror URL or fallback
   protected getDistributionUrl(): string {
-    // Check if mirrorUrl exists in the nodeInfo and return it if available
-    const mirrorUrl = this.nodeInfo.mirrorURL;
-    if (mirrorUrl) {
-      core.info(`Downloding Using mirror URL: ${mirrorUrl}`);
-      return mirrorUrl;
+    
+    if (this.nodeInfo.mirrorURL) {
+      if(this.nodeInfo.mirrorURL != '') {
+      return this.nodeInfo.mirrorURL;
+    }else{
+      if(this.nodeInfo.mirrorURL === '') {
+        throw new Error('Mirror URL is empty. Please provide a valid mirror URL.');
+      }else{
+        throw new Error('Mirror URL is not a valid');
+      }
     }
-
-    // Default to the official Node.js nightly distribution URL if no mirror URL is provided
-    core.info('Using default distribution URL for nightly Node.js.');
+   
+  }else{
     return 'https://nodejs.org/download/nightly';
   }
+  
+}
 }

--- a/src/distributions/nightly/nightly_builds.ts
+++ b/src/distributions/nightly/nightly_builds.ts
@@ -20,7 +20,7 @@ export default class NightlyNodejs extends BasePrereleaseNodejs {
     // Check if mirrorUrl exists in the nodeInfo and return it if available
     const mirrorUrl = this.nodeInfo.mirrorURL;
     if (mirrorUrl) {
-      core.info(`Downloding Using mirror URL: ${mirrorUrl}`);
+      
       return mirrorUrl;
     }
 

--- a/src/distributions/nightly/nightly_builds.ts
+++ b/src/distributions/nightly/nightly_builds.ts
@@ -20,7 +20,7 @@ export default class NightlyNodejs extends BasePrereleaseNodejs {
     // Check if mirrorUrl exists in the nodeInfo and return it if available
     const mirrorUrl = this.nodeInfo.mirrorURL;
     if (mirrorUrl) {
-      
+      core.info(`Downloding Using mirror URL: ${mirrorUrl}`);
       return mirrorUrl;
     }
 

--- a/src/distributions/nightly/nightly_builds.ts
+++ b/src/distributions/nightly/nightly_builds.ts
@@ -20,7 +20,7 @@ export default class NightlyNodejs extends BasePrereleaseNodejs {
     // Check if mirrorUrl exists in the nodeInfo and return it if available
     const mirrorUrl = this.nodeInfo.mirrorURL;
     if (mirrorUrl) {
-      core.info(`Using mirror URL: ${mirrorUrl}`);
+      core.info(`Downloding Using mirror URL: ${mirrorUrl}`);
       return mirrorUrl;
     }
 

--- a/src/distributions/official_builds/official_builds.ts
+++ b/src/distributions/official_builds/official_builds.ts
@@ -315,12 +315,17 @@ export default class OfficialBuilds extends BaseDistribution {
 
   protected async downloadFromMirrorURL() {
     const nodeJsVersions = await this.getNodeJsVersions();
+    core.info('versions from nodeJSVersions'+nodeJsVersions);
     const versions = this.filterVersions(nodeJsVersions);
+    core.info('versions'+versions);
+
     const evaluatedVersion = this.evaluateVersions(versions);
 
     if (this.nodeInfo.checkLatest) {
       const evaluatedVersion = await this.findVersionInDist(nodeJsVersions);
       this.nodeInfo.versionSpec = evaluatedVersion;
+      core.info('versionSpec'+this.nodeInfo.versionSpec);
+
     }
 
     if (!evaluatedVersion) {

--- a/src/distributions/official_builds/official_builds.ts
+++ b/src/distributions/official_builds/official_builds.ts
@@ -198,10 +198,8 @@ export default class OfficialBuilds extends BaseDistribution {
 
   protected getDistributionMirrorUrl(): string {
     const mirrorURL = this.nodeInfo.mirrorURL;
-    if (!mirrorURL) {
-      throw new Error('Mirror URL is undefined');
-    }
-    return mirrorURL;
+   
+    return mirrorURL ?? '';
   }
 
   private getManifest(): Promise<tc.IToolRelease[]> {

--- a/src/distributions/official_builds/official_builds.ts
+++ b/src/distributions/official_builds/official_builds.ts
@@ -193,14 +193,12 @@ export default class OfficialBuilds extends BaseDistribution {
   }
 
   protected getDistributionUrl(): string {
+    if (this.nodeInfo.mirrorURL) {
+      return this.nodeInfo.mirrorURL;
+    }
     return `https://nodejs.org/dist`;
   }
-
-  protected getDistributionMirrorUrl(): string {
-    const mirrorURL = this.nodeInfo.mirrorURL;
-   
-    return mirrorURL ?? '';
-  }
+  
 
   private getManifest(): Promise<tc.IToolRelease[]> {
     core.debug('Getting manifest from actions/node-versions@main');

--- a/src/distributions/official_builds/official_builds.ts
+++ b/src/distributions/official_builds/official_builds.ts
@@ -318,14 +318,11 @@ export default class OfficialBuilds extends BaseDistribution {
 
   protected async downloadFromMirrorURL() {
     const nodeJsVersions = await this.getMirrorUrlVersions();
-    core.info('nodeJsVersions from getMirrorUrVersions '+nodeJsVersions);
     const versions = this.filterVersions(nodeJsVersions);
-    core.info('versions from filterVersions '+versions);
 
 
     const evaluatedVersion = this.evaluateVersions(versions);
 
-    core.info('evaluatedVersion from evaluatedVersions '+evaluatedVersion);
 
 
     if (!evaluatedVersion) {
@@ -336,12 +333,10 @@ export default class OfficialBuilds extends BaseDistribution {
 
     const toolName = this.getNodejsMirrorURLInfo(evaluatedVersion);
 
-    core.info('toolName from getNodejsMirrorURLInfo '+toolName);
 
 
     try {
       const toolPath = await this.downloadNodejs(toolName);
-      core.info('toolPath from downloadNodejs '+toolPath);
 
       return toolPath;
     } catch (error) {

--- a/src/distributions/official_builds/official_builds.ts
+++ b/src/distributions/official_builds/official_builds.ts
@@ -317,7 +317,7 @@ export default class OfficialBuilds extends BaseDistribution {
   }
 
   protected async downloadFromMirrorURL() {
-    const nodeJsVersions = await this.getMirrorUrVersions();
+    const nodeJsVersions = await this.getMirrorUrlVersions();
     core.info('nodeJsVersions from getMirrorUrVersions '+nodeJsVersions);
     const versions = this.filterVersions(nodeJsVersions);
     core.info('versions from filterVersions '+versions);

--- a/src/distributions/official_builds/official_builds.ts
+++ b/src/distributions/official_builds/official_builds.ts
@@ -323,7 +323,7 @@ export default class OfficialBuilds extends BaseDistribution {
 
     if (!evaluatedVersion) {
       throw new Error(
-        `Unable to find Node version '${this.nodeInfo.versionSpec}' for platform ${this.osPlat} and architecture ${this.nodeInfo.arch}.`
+        `Unable to find Node version '${this.nodeInfo.versionSpec}' for platform ${this.osPlat} and architecture ${this.nodeInfo.arch} from the provided ${this.nodeInfo.mirrorURL}.`
       );
     }
 

--- a/src/distributions/official_builds/official_builds.ts
+++ b/src/distributions/official_builds/official_builds.ts
@@ -320,12 +320,12 @@ export default class OfficialBuilds extends BaseDistribution {
     core.info('versions'+versions);
 
     const evaluatedVersion = this.evaluateVersions(versions);
-
+    core.info('eversions'+evaluatedVersion);
     if (this.nodeInfo.checkLatest) {
       const evaluatedVersion = await this.findVersionInDist(nodeJsVersions);
       this.nodeInfo.versionSpec = evaluatedVersion;
       core.info('versionSpec'+this.nodeInfo.versionSpec);
-
+      
     }
 
     if (!evaluatedVersion) {

--- a/src/distributions/official_builds/official_builds.ts
+++ b/src/distributions/official_builds/official_builds.ts
@@ -323,7 +323,7 @@ export default class OfficialBuilds extends BaseDistribution {
 
     if (!evaluatedVersion) {
       throw new Error(
-        `Unable to find Node version '${this.nodeInfo.versionSpec}' for platform ${this.osPlat} and architecture ${this.nodeInfo.arch} from the provided ${this.nodeInfo.mirrorURL}.`
+        `Unable to find Node version '${this.nodeInfo.versionSpec}' for platform ${this.osPlat} and architecture ${this.nodeInfo.arch} from the provided mirror-url ${this.nodeInfo.mirrorURL}. Please check the mirror-url`
       );
     }
 

--- a/src/distributions/official_builds/official_builds.ts
+++ b/src/distributions/official_builds/official_builds.ts
@@ -16,6 +16,9 @@ export default class OfficialBuilds extends BaseDistribution {
 
   public async setupNodeJs() {
     if (this.nodeInfo.mirrorURL) {
+      if (this.nodeInfo.mirrorURL === '') {
+        throw new Error('Mirror URL is empty. Please provide a valid mirror URL.');
+    }
       let downloadPath = '';
       let toolPath = '';
       try {

--- a/src/distributions/official_builds/official_builds.ts
+++ b/src/distributions/official_builds/official_builds.ts
@@ -318,6 +318,11 @@ export default class OfficialBuilds extends BaseDistribution {
     const versions = this.filterVersions(nodeJsVersions);
     const evaluatedVersion = this.evaluateVersions(versions);
 
+    if (this.nodeInfo.checkLatest) {
+      const evaluatedVersion = await this.findVersionInDist(nodeJsVersions);
+      this.nodeInfo.versionSpec = evaluatedVersion;
+    }
+
     if (!evaluatedVersion) {
       throw new Error(
         `Unable to find Node version '${this.nodeInfo.versionSpec}' for platform ${this.osPlat} and architecture ${this.nodeInfo.arch}.`

--- a/src/distributions/official_builds/official_builds.ts
+++ b/src/distributions/official_builds/official_builds.ts
@@ -320,7 +320,8 @@ export default class OfficialBuilds extends BaseDistribution {
     core.info('versions'+versions);
 
     const evaluatedVersion = this.evaluateVersions(versions);
-    core.info('eversions'+evaluatedVersion);
+    core.info('versionSpec'+this.nodeInfo.versionSpec);
+    
     if (this.nodeInfo.checkLatest) {
       const evaluatedVersion = await this.findVersionInDist(nodeJsVersions);
       this.nodeInfo.versionSpec = evaluatedVersion;

--- a/src/distributions/official_builds/official_builds.ts
+++ b/src/distributions/official_builds/official_builds.ts
@@ -21,6 +21,7 @@ export default class OfficialBuilds extends BaseDistribution {
       try {
         core.info(`Attempting to download using mirror URL...`);
         downloadPath = await this.downloadFromMirrorURL(); // Attempt to download from the mirror
+        core.info('downloadPath from downloadFromMirrorURL() '+ downloadPath);
         if (downloadPath) {
           toolPath = downloadPath;
         }
@@ -317,9 +318,15 @@ export default class OfficialBuilds extends BaseDistribution {
 
   protected async downloadFromMirrorURL() {
     const nodeJsVersions = await this.getMirrorUrVersions();
+    core.info('nodeJsVersions from getMirrorUrVersions '+nodeJsVersions);
     const versions = this.filterVersions(nodeJsVersions);
+    core.info('versions from filterVersions '+versions);
+
 
     const evaluatedVersion = this.evaluateVersions(versions);
+
+    core.info('evaluatedVersion from evaluatedVersions '+evaluatedVersion);
+
 
     if (!evaluatedVersion) {
       throw new Error(
@@ -329,8 +336,13 @@ export default class OfficialBuilds extends BaseDistribution {
 
     const toolName = this.getNodejsMirrorURLInfo(evaluatedVersion);
 
+    core.info('toolName from getNodejsMirrorURLInfo '+toolName);
+
+
     try {
       const toolPath = await this.downloadNodejs(toolName);
+      core.info('toolPath from downloadNodejs '+toolPath);
+
       return toolPath;
     } catch (error) {
       if (error instanceof tc.HTTPError && error.httpStatusCode === 404) {

--- a/src/distributions/official_builds/official_builds.ts
+++ b/src/distributions/official_builds/official_builds.ts
@@ -342,11 +342,14 @@ export default class OfficialBuilds extends BaseDistribution {
       return toolPath;
     } catch (error) {
       if (error instanceof tc.HTTPError && error.httpStatusCode === 404) {
-        core.warning(
+        core.error(
           `Node version ${this.nodeInfo.versionSpec} for platform ${this.osPlat} and architecture ${this.nodeInfo.arch} was found but failed to download. ` +
-            'This usually happens when downloadable binaries are not fully updated at https://nodejs.org/. ' +
-            'To resolve this issue you may either fall back to the older version or try again later.'
+          'This usually happens when downloadable binaries are not fully updated at https://nodejs.org/. ' +
+          'To resolve this issue you may either fall back to the older version or try again later.'
         );
+      } else {
+        // For any other error type, you can log the error message.
+        core.error(`An unexpected error occurred like url might not correct`);
       }
 
       throw error;

--- a/src/distributions/rc/rc_builds.ts
+++ b/src/distributions/rc/rc_builds.ts
@@ -3,24 +3,30 @@ import {NodeInputs} from '../base-models';
 import * as core from '@actions/core';
 
 export default class RcBuild extends BaseDistribution {
+  getDistributionMirrorUrl() {
+    throw new Error('Method not implemented.');
+  }
 
   constructor(nodeInfo: NodeInputs) {
     super(nodeInfo);
   }
-
-  getDistributionUrl(): string {
+  protected getDistributionUrl(): string {
+    
+    if (this.nodeInfo.mirrorURL) {
+      if(this.nodeInfo.mirrorURL != '') {
+      return this.nodeInfo.mirrorURL;
+    }else{
+      if(this.nodeInfo.mirrorURL === '') {
+        throw new Error('Mirror URL is empty. Please provide a valid mirror URL.');
+      }else{
+        throw new Error('Mirror URL is not a valid');
+      }
+    }
+   
+  }else{
     return 'https://nodejs.org/download/rc';
   }
-
-  protected getDistributionMirrorUrl(): string {
-    // Check if mirrorUrl exists in the nodeInfo and return it if available
-    const mirrorUrl = this.nodeInfo.mirrorURL;
-    if (mirrorUrl) {
-      core.info(`Using mirror URL: ${mirrorUrl}`);
-      return mirrorUrl;
-    }
-
-    // Return the default URL if no mirror URL is provided
-    return this.getDistributionUrl();
-  }
+  
 }
+  }
+

--- a/src/distributions/rc/rc_builds.ts
+++ b/src/distributions/rc/rc_builds.ts
@@ -1,12 +1,26 @@
 import BaseDistribution from '../base-distribution';
 import {NodeInputs} from '../base-models';
+import * as core from '@actions/core';
 
 export default class RcBuild extends BaseDistribution {
+
   constructor(nodeInfo: NodeInputs) {
     super(nodeInfo);
   }
 
   getDistributionUrl(): string {
     return 'https://nodejs.org/download/rc';
+  }
+
+  protected getDistributionMirrorUrl(): string {
+    // Check if mirrorUrl exists in the nodeInfo and return it if available
+    const mirrorUrl = this.nodeInfo.mirrorURL;
+    if (mirrorUrl) {
+      core.info(`Using mirror URL: ${mirrorUrl}`);
+      return mirrorUrl;
+    }
+
+    // Return the default URL if no mirror URL is provided
+    return this.getDistributionUrl();
   }
 }

--- a/src/distributions/v8-canary/canary_builds.ts
+++ b/src/distributions/v8-canary/canary_builds.ts
@@ -1,13 +1,24 @@
 import BasePrereleaseNodejs from '../base-distribution-prerelease';
 import {NodeInputs} from '../base-models';
-
+import * as core from '@actions/core';
 export default class CanaryBuild extends BasePrereleaseNodejs {
+  
   protected distribution = 'v8-canary';
   constructor(nodeInfo: NodeInputs) {
     super(nodeInfo);
   }
 
   protected getDistributionUrl(): string {
+    return 'https://nodejs.org/download/v8-canary';
+  }
+
+  protected getDistributionMirrorUrl(): string {
+    // Check if mirrorUrl exists in the nodeInfo and return it if available
+    const mirrorUrl = this.nodeInfo.mirrorURL;
+    if (mirrorUrl) {
+      core.info(`Using mirror URL: ${mirrorUrl}`);
+      return mirrorUrl;
+    }
     return 'https://nodejs.org/download/v8-canary';
   }
 }

--- a/src/distributions/v8-canary/canary_builds.ts
+++ b/src/distributions/v8-canary/canary_builds.ts
@@ -9,16 +9,21 @@ export default class CanaryBuild extends BasePrereleaseNodejs {
   }
 
   protected getDistributionUrl(): string {
-    return 'https://nodejs.org/download/v8-canary';
-  }
-
-  protected getDistributionMirrorUrl(): string {
-    // Check if mirrorUrl exists in the nodeInfo and return it if available
-    const mirrorUrl = this.nodeInfo.mirrorURL;
-    if (mirrorUrl) {
-      core.info(`Using mirror URL: ${mirrorUrl}`);
-      return mirrorUrl;
+    
+    if (this.nodeInfo.mirrorURL) {
+      if(this.nodeInfo.mirrorURL != '') {
+      return this.nodeInfo.mirrorURL;
+    }else{
+      if(this.nodeInfo.mirrorURL === '') {
+        throw new Error('Mirror URL is empty. Please provide a valid mirror URL.');
+      }else{
+        throw new Error('Mirror URL is not a valid');
+      }
     }
+   
+  }else{
     return 'https://nodejs.org/download/v8-canary';
   }
+  
+}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ export async function run() {
       arch = os.arch();
     }
 
-    const mirrorURL = core.getInput('mirrorURL').trim(); // .trim() to remove any accidental spaces
+    const mirrorURL = core.getInput('mirror-url').trim(); // .trim() to remove any accidental spaces
 
 
     if (version) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,9 @@ export async function run() {
       arch = os.arch();
     }
 
+    const mirrorURL = core.getInput('mirrorURL').trim(); // .trim() to remove any accidental spaces
+
+
     if (version) {
       const token = core.getInput('token');
       const auth = !token ? undefined : `token ${token}`;
@@ -45,7 +48,8 @@ export async function run() {
         checkLatest,
         auth,
         stable,
-        arch
+        arch,
+        mirrorURL
       };
       const nodeDistribution = getNodejsDistribution(nodejsInfo);
       await nodeDistribution.setupNodeJs();

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,6 @@ export async function run() {
 
     const mirrorURL = core.getInput('mirror-url').trim(); // .trim() to remove any accidental spaces
 
-
     if (version) {
       const token = core.getInput('token');
       const auth = !token ? undefined : `token ${token}`;


### PR DESCRIPTION
**Description:**
This PR introduces a new mirror-url parameter that allows users to specify a custom mirror for downloading Node.js. This feature provides flexibility for environments where the default Node.js download mirrors are not accessible or where a specific mirror is preferred.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.