### PR TITLE
[docs] Add link to the engines.node field definition.

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -72,6 +72,7 @@ steps:
 ```
 
 When using the `package.json` input, the action will look for `volta.node` first. If `volta.node` isn't defined, then it will look for `engines.node`.
+(The latter is defined [here in the npm docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json/#engines).)
 
 ```json
 {


### PR DESCRIPTION
**Description:**
Added a link to the definition of the `engines.node` field in `package.json`.

**Related issue:**
Closes #1081.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.