### PR TITLE
Add note about NVM and latest release syntax being outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Examples:
  - NVM LTS syntax: `lts/erbium`, `lts/fermium`, `lts/*`, `lts/-n`
  - Latest release: `*` or `latest`/`current`/`node`
 
-**Note:** Like the other values, `*` will get the latest [locally-cached Node.js version](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#nodejs), or the latest version from [actions/node-versions](https://github.com/actions/node-versions/blob/main/versions-manifest.json), depending on the [`check-latest`](docs/advanced-usage.md#check-latest-version) input.
+**Note:** If you require timely version upgrades, use specific versions like `22.18.0` and upgrade the versions yourself. Values like `lts/*`, `*`, `latest`, etc. will get the latest [locally-cached Node.js version](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#nodejs), or the latest version from [actions/node-versions](https://github.com/actions/node-versions/blob/main/versions-manifest.json), depending on the [`check-latest`](docs/advanced-usage.md#check-latest-version) input. Both can be several days outdated.
 
 `current`/`latest`/`node` always resolve to the latest [dist version](https://nodejs.org/dist/index.json).
 That version is then downloaded from actions/node-versions if possible, or directly from Node.js if not.


### PR DESCRIPTION
Closes #1236 
Closes #1114
Closes #940


**Description:**

As extensively documented in #1236 and #940, the non-exact aliases `lts/*`, `*`, `current`, `latest`, and `22` are slow to be upgraded, lagging several days behind the Node.js releases.

Let users know about this downside.

**Related issue:**

- #1236 
- #1114
- #940

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.