### PR TITLE
refactor: minor changes follows #1348

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -71,7 +71,7 @@ export async function run() {
     if (isCacheFeatureAvailable()) {
       // we only determine the package manager type if we can cache in the first place
       if (cache) {
-        // in previous version of setup-node, user can explictly specify what package manager they are using, we prefer that
+        // in previous version of setup-node, user can explicitly specify what package manager they are using, we prefer that
         core.saveState(State.CachePackageManager, cache);
         await restoreCache(cache, cacheDependencyPath);
       } else if (packagemanagercache) {


### PR DESCRIPTION
**Description:**

The PR follows #1348 with a bugfix and a very slight performance improvement.

- Only enable package cache when the cache feature is available
  - In #1348 new `package-manager-cache` logic is not guarded by `isCacheFeatureAvailable()`, the PR fixes this.
- Don't read `package.json` if the previous version's `cache` config is used
  - We don't have to determine the package manager if the user has explicitly specified which package manager to use, which improves performance a little.

**Related issue:**

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.