### PR TITLE
Remove redundant direct dependency 'jest-each'

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -8,8 +8,6 @@ import fs from 'fs';
 import path from 'path';
 import osm from 'os';
 
-import each from 'jest-each';
-
 import * as main from '../src/main';
 import * as util from '../src/util';
 import OfficialBuilds from '../src/distributions/official_builds/official_builds';
@@ -93,7 +91,7 @@ describe('main tests', () => {
   }, 100000);
 
   describe('getNodeVersionFromFile', () => {
-    each`
+    it.each`
       contents                                     | expected
       ${'12'}                                      | ${'12'}
       ${'12.3'}                                    | ${'12.3'}
@@ -110,7 +108,7 @@ describe('main tests', () => {
       ${'{"volta": {"extends": "./package.json"}}'}| ${'18.0.0'}
       ${'{"engines": {"node": "17.0.0"}}'}         | ${'17.0.0'}
       ${'{}'}                                      | ${null}
-    `.it('parses "$contents"', ({contents, expected}) => {
+    `('parses "$contents"', ({contents, expected}) => {
       const existsSpy = jest.spyOn(fs, 'existsSync');
       existsSpy.mockImplementation(() => true);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "eslint-plugin-node": "^11.1.0",
         "jest": "^29.7.0",
         "jest-circus": "^29.7.0",
-        "jest-each": "^29.7.0",
         "prettier": "^3.6.2",
         "ts-jest": "^29.4.1",
         "typescript": "^5.4.2"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "eslint-plugin-node": "^11.1.0",
     "jest": "^29.7.0",
     "jest-circus": "^29.7.0",
-    "jest-each": "^29.7.0",
     "prettier": "^3.6.2",
     "ts-jest": "^29.4.1",
     "typescript": "^5.4.2"


### PR DESCRIPTION
**Description:**
Removes redundant test dependency 'jest-each'

**Related issue:**
N/A

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.