### PR TITLE
Add example for restore-only cache in documentation

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -327,7 +327,7 @@ jobs:
       - run: npm install
 ```
 
-> **Note**: Using a restore-only cache avoids redundant writes to the cache, which can reduce workflow time and minimize cache storage usage, as referenced in cache scenarios for [Node – npm](https://github.com/actions/cache/blob/main/examples.md#node---npm).
+> For more details related to cache scenarios, please refer [Node – npm](https://github.com/actions/cache/blob/main/examples.md#node---npm).
 
 ## Multiple Operating Systems and Architectures
 


### PR DESCRIPTION
**Description:**
This PR adds documentation and an example workflow demonstrating how to achieve restore-only caching with setup-node using the actions/cache.
The update is based on community feedback from [#663](https://github.com/actions/setup-node/issues/663) (“Add option to restore cache only”), which proposed adding a restore-only flag to the action.
Instead of introducing new functionality, this documentation clarifies how users can already achieve this behavior using actions/cache.
**Related issue:**
[#663](https://github.com/actions/setup-node/issues/663)

**Check list:**
- [ X] Mark if documentation changes are required.