### PR TITLE
README.md: bump to latest released checkout version v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ See [action.yml](action.yml)
 
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-node@v6
   with:
     node-version: 24
@@ -164,7 +164,7 @@ See the examples of using cache for `yarn`/`pnpm` and `cache-dependency-path` in
 
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-node@v6
   with:
     node-version: 24
@@ -177,7 +177,7 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-node@v6
   with:
     node-version: 24
@@ -193,7 +193,7 @@ This behavior is controlled by the `package-manager-cache` input, which defaults
 
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-node@v6
   with:
     package-manager-cache: false
@@ -212,7 +212,7 @@ jobs:
         node: [ 20, 22, 24 ]
     name: Node ${{ matrix.node }} sample
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup node
         uses: actions/setup-node@v6
         with:

--- a/docs/adrs/0001-support-caching-deps-for-monorepos.md
+++ b/docs/adrs/0001-support-caching-deps-for-monorepos.md
@@ -8,7 +8,7 @@ Currently, `actions/setup-node` supports caching dependencies for Npm and Yarn p
 For the first iteration, we have decided to not support cases where `package-lock.json` / `yarn.lock` are located outside of repository root.  
 Current implementation searches the following file patterns in the repository root: `package-lock.json`, `yarn.lock` (in order of resolving priorities)
 
-Obviously, it made build-in caching unusable for mono-repos and repos with complex structure.  
+Obviously, it made built-in caching unusable for mono-repos and repos with complex structure.  
 We would like to revisit this decision and add customization for dependencies lock file location.
 
 ## Proposal
@@ -24,7 +24,7 @@ The second option looks more generic because it allows to:
 ## Decision
 
 Add `cache-dependency-path` input that will accept path (relative to repository root) to dependencies lock file.  
-If provided path contains wildcards, the action will search all maching files and calculate common hash like `${{ hashFiles('**/package-lock.json') }}` YAML construction does.  
+If provided path contains wildcards, the action will search all matching files and calculate common hash like `${{ hashFiles('**/package-lock.json') }}` YAML construction does.  
 The hash of provided matched files will be used as a part of cache key.
 
 Yaml examples:


### PR DESCRIPTION
This PR updates the given versions of checkout action to v6 in `README.md`.
This PR also fixes two typos on the fly.