### PR TITLE
fix: remove hardcoded bearer

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -54246,7 +54246,7 @@ class BaseDistribution {
         const dataUrl = `${initialUrl}/index.json`;
         const headers = {};
         if (this.nodeInfo.mirrorToken) {
-            headers['Authorization'] = `Bearer ${this.nodeInfo.mirrorToken}`;
+            headers['Authorization'] = this.nodeInfo.mirrorToken;
         }
         const response = await this.httpClient.getJson(dataUrl, headers);
         return response.result || [];

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -470,7 +470,7 @@ Please refer to the [Ensuring workflow access to your package - Configuring a pa
 It is possible to use a private mirror hosting Node.js binaries. This mirror must be a full mirror of the official Node.js distribution.
 The mirror URL can be set using the `mirror` input.
 It is possible to specify a token to authenticate with the mirror using the `mirror-token` input.
-The token will be passed as a bearer token in the `Authorization` header.
+The token will be passed in the `Authorization` header.
 
 ```yaml
 - uses: actions/setup-node@v6

--- a/src/distributions/base-distribution.ts
+++ b/src/distributions/base-distribution.ts
@@ -103,7 +103,7 @@ export default abstract class BaseDistribution {
     const headers = {};
 
     if (this.nodeInfo.mirrorToken) {
-      headers['Authorization'] = `Bearer ${this.nodeInfo.mirrorToken}`;
+      headers['Authorization'] = this.nodeInfo.mirrorToken;
     }
 
     const response = await this.httpClient.getJson<INodeVersion[]>(


### PR DESCRIPTION
Followup of https://github.com/actions/setup-node/pull/1240

**Description:**
This change makes the mirror usable.
Right now Immagine we setup the value of `mirror-token` to `foo`.
In this line the value is used as
https://github.com/actions/setup-node/blob/2951748f4c016b747952f8ca7e75fc64f2f62b53/src/distributions/base-distribution.ts#L106

`Bearer foo` but in other places such as:
https://github.com/actions/setup-node/blob/2951748f4c016b747952f8ca7e75fc64f2f62b53/src/distributions/base-distribution.ts#L149

https://github.com/actions/setup-node/blob/2951748f4c016b747952f8ca7e75fc64f2f62b53/src/distributions/base-distribution.ts#L210

its used as is.

But if we change the value to `Bearer foo`,
https://github.com/actions/setup-node/blob/2951748f4c016b747952f8ca7e75fc64f2f62b53/src/distributions/base-distribution.ts#L106
here it becomes `Bearer Bearer foo` which is incorrect, but works everywhere else.


So this PR makes it that if its a `Bearer`, the user needs to be explicit.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.