### PR TITLE
fix(#1027): Improve yarn v4+ corepack support with better error handling

### DIFF
--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -44172,7 +44172,24 @@ exports.supportedPackageManagers = {
         name: 'yarn',
         lockFilePatterns: ['yarn.lock'],
         getCacheFolderPath: async (projectDir) => {
-            const yarnVersion = await (0, exports.getCommandOutputNotEmpty)(`yarn --version`, 'Could not retrieve version of yarn', projectDir);
+            // Try to enable corepack first if available
+            // This helps with yarn v2+ which requires corepack
+            await enableCorepackIfSupported();
+            let yarnVersion;
+            try {
+                yarnVersion = await (0, exports.getCommandOutputNotEmpty)(`yarn --version`, 'Could not retrieve version of yarn', projectDir);
+            }
+            catch (err) {
+                // Check if this is a corepack error message
+                const errorMsg = err.message;
+                if (errorMsg.includes('packageManager') &&
+                    errorMsg.includes('Corepack')) {
+                    throw new Error(`Yarn v4+ requires corepack to be enabled. Please run 'corepack enable' before using ` +
+                        `actions/setup-node with yarn, or disable caching with 'package-manager-cache: false'. ` +
+                        `See: https://github.com/actions/setup-node/issues/1027 for more information.`);
+                }
+                throw err;
+            }
             core.debug(`Consumed yarn version is ${yarnVersion} (working dir: "${projectDir || ''}")`);
             const stdOut = yarnVersion.startsWith('1.')
                 ? await (0, exports.getCommandOutput)('yarn cache dir', projectDir)
@@ -44182,6 +44199,24 @@ exports.supportedPackageManagers = {
             }
             return stdOut;
         }
+    }
+};
+/**
+ * Tries to enable corepack for Node.js versions that support it (16.9+)
+ * This helps with yarn v2+ which requires corepack
+ * See: https://github.com/actions/setup-node/issues/1027
+ */
+const enableCorepackIfSupported = async () => {
+    try {
+        await exec.exec('corepack', ['enable'], {
+            ignoreReturnCode: true,
+            silent: true
+        });
+        core.debug('Corepack enabled successfully');
+    }
+    catch {
+        // Corepack not available or failed silently
+        core.debug('Corepack not available on this system');
     }
 };
 const getCommandOutput = async (toolCommand, cwd) => {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -53810,7 +53810,24 @@ exports.supportedPackageManagers = {
         name: 'yarn',
         lockFilePatterns: ['yarn.lock'],
         getCacheFolderPath: async (projectDir) => {
-            const yarnVersion = await (0, exports.getCommandOutputNotEmpty)(`yarn --version`, 'Could not retrieve version of yarn', projectDir);
+            // Try to enable corepack first if available
+            // This helps with yarn v2+ which requires corepack
+            await enableCorepackIfSupported();
+            let yarnVersion;
+            try {
+                yarnVersion = await (0, exports.getCommandOutputNotEmpty)(`yarn --version`, 'Could not retrieve version of yarn', projectDir);
+            }
+            catch (err) {
+                // Check if this is a corepack error message
+                const errorMsg = err.message;
+                if (errorMsg.includes('packageManager') &&
+                    errorMsg.includes('Corepack')) {
+                    throw new Error(`Yarn v4+ requires corepack to be enabled. Please run 'corepack enable' before using ` +
+                        `actions/setup-node with yarn, or disable caching with 'package-manager-cache: false'. ` +
+                        `See: https://github.com/actions/setup-node/issues/1027 for more information.`);
+                }
+                throw err;
+            }
             core.debug(`Consumed yarn version is ${yarnVersion} (working dir: "${projectDir || ''}")`);
             const stdOut = yarnVersion.startsWith('1.')
                 ? await (0, exports.getCommandOutput)('yarn cache dir', projectDir)
@@ -53820,6 +53837,24 @@ exports.supportedPackageManagers = {
             }
             return stdOut;
         }
+    }
+};
+/**
+ * Tries to enable corepack for Node.js versions that support it (16.9+)
+ * This helps with yarn v2+ which requires corepack
+ * See: https://github.com/actions/setup-node/issues/1027
+ */
+const enableCorepackIfSupported = async () => {
+    try {
+        await exec.exec('corepack', ['enable'], {
+            ignoreReturnCode: true,
+            silent: true
+        });
+        core.debug('Corepack enabled successfully');
+    }
+    catch {
+        // Corepack not available or failed silently
+        core.debug('Corepack not available on this system');
     }
 };
 const getCommandOutput = async (toolCommand, cwd) => {

--- a/src/cache-utils.ts
+++ b/src/cache-utils.ts
@@ -40,11 +40,32 @@ export const supportedPackageManagers: SupportedPackageManagers = {
     name: 'yarn',
     lockFilePatterns: ['yarn.lock'],
     getCacheFolderPath: async projectDir => {
-      const yarnVersion = await getCommandOutputNotEmpty(
-        `yarn --version`,
-        'Could not retrieve version of yarn',
-        projectDir
-      );
+      // Try to enable corepack first if available
+      // This helps with yarn v2+ which requires corepack
+      await enableCorepackIfSupported();
+
+      let yarnVersion: string;
+      try {
+        yarnVersion = await getCommandOutputNotEmpty(
+          `yarn --version`,
+          'Could not retrieve version of yarn',
+          projectDir
+        );
+      } catch (err) {
+        // Check if this is a corepack error message
+        const errorMsg = (err as Error).message;
+        if (
+          errorMsg.includes('packageManager') &&
+          errorMsg.includes('Corepack')
+        ) {
+          throw new Error(
+            `Yarn v4+ requires corepack to be enabled. Please run 'corepack enable' before using ` +
+              `actions/setup-node with yarn, or disable caching with 'package-manager-cache: false'. ` +
+              `See: https://github.com/actions/setup-node/issues/1027 for more information.`
+          );
+        }
+        throw err;
+      }
 
       core.debug(
         `Consumed yarn version is ${yarnVersion} (working dir: "${
@@ -63,6 +84,24 @@ export const supportedPackageManagers: SupportedPackageManagers = {
       }
       return stdOut;
     }
+  }
+};
+
+/**
+ * Tries to enable corepack for Node.js versions that support it (16.9+)
+ * This helps with yarn v2+ which requires corepack
+ * See: https://github.com/actions/setup-node/issues/1027
+ */
+const enableCorepackIfSupported = async (): Promise<void> => {
+  try {
+    await exec.exec('corepack', ['enable'], {
+      ignoreReturnCode: true,
+      silent: true
+    });
+    core.debug('Corepack enabled successfully');
+  } catch {
+    // Corepack not available or failed silently
+    core.debug('Corepack not available on this system');
   }
 };
 


### PR DESCRIPTION
### Problem
Yarn v4+ requires corepack, but the action tried to use yarn v1.22.22 from the system,
causing the error:


### Solution
- Automatically enable corepack before checking yarn version (for Node 16.9+)
- Detect corepack errors and provide clear, actionable messages
- Users can either enable corepack first or disable caching

### Changes
- Added `enableCorepackIfSupported()` helper function
- Updated yarn `getCacheFolderPath()` to enable corepack and detect version mismatch errors
- Improved error messages with links to GitHub issue

### Testing
- Builds successfully without errors
- Error messages guide users to solution

