### PR TITLE
Add support for parsing the devEngines field

### DIFF
--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -168,6 +168,21 @@ jobs:
       - name: Verify node
         run: __tests__/verify-node.sh 24
 
+  version-file-dev-engines:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-large]
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup node from node version file
+        uses: ./
+        with:
+          node-version-file: '__tests__/data/package-dev-engines.json'
+      - name: Verify node
+        run: __tests__/verify-node.sh 24
+
   version-file-volta:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/__tests__/data/package-dev-engines.json
+++ b/__tests__/data/package-dev-engines.json
@@ -1,0 +1,11 @@
+{
+  "engines": {
+    "node": "^19"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "^24"
+    }
+  }
+}

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -94,22 +94,24 @@ describe('main tests', () => {
 
   describe('getNodeVersionFromFile', () => {
     each`
-      contents                                     | expected
-      ${'12'}                                      | ${'12'}
-      ${'12.3'}                                    | ${'12.3'}
-      ${'12.3.4'}                                  | ${'12.3.4'}
-      ${'v12.3.4'}                                 | ${'12.3.4'}
-      ${'lts/erbium'}                              | ${'lts/erbium'}
-      ${'lts/*'}                                   | ${'lts/*'}
-      ${'nodejs 12.3.4'}                           | ${'12.3.4'}
-      ${'ruby 2.3.4\nnodejs 12.3.4\npython 3.4.5'} | ${'12.3.4'}
-      ${''}                                        | ${''}
-      ${'unknown format'}                          | ${'unknown format'}
-      ${'  14.1.0  '}                              | ${'14.1.0'}
-      ${'{"volta": {"node": ">=14.0.0 <=17.0.0"}}'}| ${'>=14.0.0 <=17.0.0'}
-      ${'{"volta": {"extends": "./package.json"}}'}| ${'18.0.0'}
-      ${'{"engines": {"node": "17.0.0"}}'}         | ${'17.0.0'}
-      ${'{}'}                                      | ${null}
+      contents                                                                                   | expected
+      ${'12'}                                                                                    | ${'12'}
+      ${'12.3'}                                                                                  | ${'12.3'}
+      ${'12.3.4'}                                                                                | ${'12.3.4'}
+      ${'v12.3.4'}                                                                               | ${'12.3.4'}
+      ${'lts/erbium'}                                                                            | ${'lts/erbium'}
+      ${'lts/*'}                                                                                 | ${'lts/*'}
+      ${'nodejs 12.3.4'}                                                                         | ${'12.3.4'}
+      ${'ruby 2.3.4\nnodejs 12.3.4\npython 3.4.5'}                                               | ${'12.3.4'}
+      ${''}                                                                                      | ${''}
+      ${'unknown format'}                                                                        | ${'unknown format'}
+      ${'  14.1.0  '}                                                                            | ${'14.1.0'}
+      ${'{}'}                                                                                    | ${null}
+      ${'{"volta": {"node": ">=14.0.0 <=17.0.0"}}'}                                              | ${'>=14.0.0 <=17.0.0'}
+      ${'{"volta": {"extends": "./package.json"}}'}                                              | ${'18.0.0'}
+      ${'{"engines": {"node": "17.0.0"}}'}                                                       | ${'17.0.0'}
+      ${'{"devEngines": {"runtime": {"name": "node", "version": "22.0.0"}}}'}                    | ${'22.0.0'}
+      ${'{"devEngines": {"runtime": [{"name": "bun"}, {"name": "node", "version": "22.0.0"}]}}'} | ${'22.0.0'}
     `.it('parses "$contents"', ({contents, expected}) => {
       const existsSpy = jest.spyOn(fs, 'existsSync');
       existsSpy.mockImplementation(() => true);

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -94,24 +94,26 @@ describe('main tests', () => {
 
   describe('getNodeVersionFromFile', () => {
     each`
-      contents                                                                                   | expected
-      ${'12'}                                                                                    | ${'12'}
-      ${'12.3'}                                                                                  | ${'12.3'}
-      ${'12.3.4'}                                                                                | ${'12.3.4'}
-      ${'v12.3.4'}                                                                               | ${'12.3.4'}
-      ${'lts/erbium'}                                                                            | ${'lts/erbium'}
-      ${'lts/*'}                                                                                 | ${'lts/*'}
-      ${'nodejs 12.3.4'}                                                                         | ${'12.3.4'}
-      ${'ruby 2.3.4\nnodejs 12.3.4\npython 3.4.5'}                                               | ${'12.3.4'}
-      ${''}                                                                                      | ${''}
-      ${'unknown format'}                                                                        | ${'unknown format'}
-      ${'  14.1.0  '}                                                                            | ${'14.1.0'}
-      ${'{}'}                                                                                    | ${null}
-      ${'{"volta": {"node": ">=14.0.0 <=17.0.0"}}'}                                              | ${'>=14.0.0 <=17.0.0'}
-      ${'{"volta": {"extends": "./package.json"}}'}                                              | ${'18.0.0'}
-      ${'{"engines": {"node": "17.0.0"}}'}                                                       | ${'17.0.0'}
-      ${'{"devEngines": {"runtime": {"name": "node", "version": "22.0.0"}}}'}                    | ${'22.0.0'}
-      ${'{"devEngines": {"runtime": [{"name": "bun"}, {"name": "node", "version": "22.0.0"}]}}'} | ${'22.0.0'}
+      contents                                                                                                                            | expected
+      ${'12'}                                                                                                                             | ${'12'}
+      ${'12.3'}                                                                                                                           | ${'12.3'}
+      ${'12.3.4'}                                                                                                                         | ${'12.3.4'}
+      ${'v12.3.4'}                                                                                                                        | ${'12.3.4'}
+      ${'lts/erbium'}                                                                                                                     | ${'lts/erbium'}
+      ${'lts/*'}                                                                                                                          | ${'lts/*'}
+      ${'nodejs 12.3.4'}                                                                                                                  | ${'12.3.4'}
+      ${'ruby 2.3.4\nnodejs 12.3.4\npython 3.4.5'}                                                                                        | ${'12.3.4'}
+      ${''}                                                                                                                               | ${''}
+      ${'unknown format'}                                                                                                                 | ${'unknown format'}
+      ${'  14.1.0  '}                                                                                                                     | ${'14.1.0'}
+      ${'{}'}                                                                                                                             | ${null}
+      ${'{"volta": {"node": ">=14.0.0 <=17.0.0"}}'}                                                                                       | ${'>=14.0.0 <=17.0.0'}
+      ${'{"volta": {"extends": "./package.json"}}'}                                                                                       | ${'18.0.0'}
+      ${'{"engines": {"node": "17.0.0"}}'}                                                                                                | ${'17.0.0'}
+      ${'{"devEngines": {"runtime": {"name": "node", "version": "22.0.0"}}}'}                                                             | ${'22.0.0'}
+      ${'{"devEngines": {"runtime": [{"name": "bun"}, {"name": "node", "version": "22.0.0"}]}}'}                                          | ${'22.0.0'}
+      ${'{"devEngines": {"runtime": {"name": "node", "version": "22.0.0"}}, "engines": {"node": "18.0.0"}}'}                              | ${'22.0.0'}
+      ${'{"volta": {"node": "16.0.0"}, "devEngines": {"runtime": {"name": "node", "version": "22.0.0"}}, "engines": {"node": "18.0.0"}}'} | ${'16.0.0'}
     `.it('parses "$contents"', ({contents, expected}) => {
       const existsSpy = jest.spyOn(fs, 'existsSync');
       existsSpy.mockImplementation(() => true);

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -71877,6 +71877,17 @@ function getNodeVersionFromFile(versionFilePath) {
             if (manifest.volta?.node) {
                 return manifest.volta.node;
             }
+            // support devEngines from npm 11
+            if (manifest.devEngines?.runtime) {
+                // find an entry with name set to node and having set a version.
+                // the devEngines.runtime can either be an object or an array of objects
+                const nodeEntry = [manifest.devEngines.runtime]
+                    .flat()
+                    .find(({ name, version }) => name?.toLowerCase() === 'node' && version);
+                if (nodeEntry) {
+                    return nodeEntry.version;
+                }
+            }
             if (manifest.engines?.node) {
                 return manifest.engines.node;
             }

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -90,7 +90,11 @@ steps:
 - run: npm test
 ```
 
-When using the `package.json` input, the action will look for `volta.node` first. If `volta.node` isn't defined, then it will look for `engines.node`.
+When using the `package.json` input, the action will look in the following fields for a specified Node version:
+1. It checks `volta.node` first.
+2. Then it checks `devEngines.runtime`.
+3. Then it will look for `engines.node`.
+4. Otherwise it tries to resolve the file defined by [`volta.extends`](https://docs.volta.sh/advanced/workspaces) and look for `volta.node`, `devEngines.runtime`, or `engines.node` recursively.
 
 ```json
 {
@@ -99,11 +103,15 @@ When using the `package.json` input, the action will look for `volta.node` first
   },
   "volta": {
     "node": "16.0.0"
-  }
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "^24.13.0"
+    }
+  }
 }
 ```
-
-Otherwise, when [`volta.extends`](https://docs.volta.sh/advanced/workspaces) is defined, then it will resolve the corresponding file and look for `volta.node` or `engines.node` recursively.
 
 ## Architecture
 

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -112,6 +112,7 @@ When using the `package.json` input, the action will look in the following field
   }
 }
 ```
+**Note:** The devEngines.runtime can either be an object or an array of objects
 
 ## Architecture
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -26,6 +26,18 @@ export function getNodeVersionFromFile(versionFilePath: string): string | null {
         return manifest.volta.node;
       }
 
+      // support devEngines from npm 11
+      if (manifest.devEngines?.runtime) {
+        // find an entry with name set to node and having set a version.
+        // the devEngines.runtime can either be an object or an array of objects
+        const nodeEntry = [manifest.devEngines.runtime]
+          .flat()
+          .find(({name, version}) => name?.toLowerCase() === 'node' && version);
+        if (nodeEntry) {
+          return nodeEntry.version;
+        }
+      }
+
       if (manifest.engines?.node) {
         return manifest.engines.node;
       }


### PR DESCRIPTION
**Description:**
This PR adds support for parsing the devEngines.runtime field (if it is set to node) for allowing automatic setup.

**Related issue:**
https://github.com/actions/setup-node/issues/1255

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.