### PR TITLE
Ensure newline after registry string in npmrc

### DIFF
--- a/__tests__/authutil.test.ts
+++ b/__tests__/authutil.test.ts
@@ -123,7 +123,7 @@ describe('authutil tests', () => {
     await auth.configAuthentication('https://registry.npmjs.org/');
     const contents = fs.readFileSync(rcFile, {encoding: 'utf8'});
     expect(contents).toBe(
-      `//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}registry=https://registry.npmjs.org/`
+      `//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}registry=https://registry.npmjs.org/${os.EOL}`
     );
   });
 
@@ -132,7 +132,7 @@ describe('authutil tests', () => {
     await auth.configAuthentication('https://registry.npmjs.org/');
     const contents = fs.readFileSync(rcFile, {encoding: 'utf8'});
     expect(contents).toBe(
-      `@myscope:registry=MMM${os.EOL}//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}registry=https://registry.npmjs.org/`
+      `@myscope:registry=MMM${os.EOL}//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}registry=https://registry.npmjs.org/${os.EOL}`
     );
   });
 
@@ -141,7 +141,7 @@ describe('authutil tests', () => {
     await auth.configAuthentication('https://registry.npmjs.org/');
     const contents = fs.readFileSync(rcFile, {encoding: 'utf8'});
     expect(contents).toBe(
-      `@myscope:registry=NNN${os.EOL}//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}registry=https://registry.npmjs.org/`
+      `@myscope:registry=NNN${os.EOL}//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}registry=https://registry.npmjs.org/${os.EOL}`
     );
   });
 
@@ -151,7 +151,7 @@ describe('authutil tests', () => {
     await auth.configAuthentication('https://registry.npmjs.org/');
     const contents = fs.readFileSync(rcFile, {encoding: 'utf8'});
     expect(contents).toBe(
-      `//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}@myscope:registry=https://registry.npmjs.org/`
+      `//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}@myscope:registry=https://registry.npmjs.org/${os.EOL}`
     );
   });
 
@@ -161,7 +161,7 @@ describe('authutil tests', () => {
     await auth.configAuthentication('https://registry.npmjs.org/');
     const contents = fs.readFileSync(rcFile, {encoding: 'utf8'});
     expect(contents).toBe(
-      `registry=NNN${os.EOL}//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}@myscope:registry=https://registry.npmjs.org/`
+      `registry=NNN${os.EOL}//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}@myscope:registry=https://registry.npmjs.org/${os.EOL}`
     );
   });
 
@@ -171,7 +171,7 @@ describe('authutil tests', () => {
     await auth.configAuthentication('https://registry.npmjs.org/');
     const contents = fs.readFileSync(rcFile, {encoding: 'utf8'});
     expect(contents).toBe(
-      `registry=MMM${os.EOL}//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}@myscope:registry=https://registry.npmjs.org/`
+      `registry=MMM${os.EOL}//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}@myscope:registry=https://registry.npmjs.org/${os.EOL}`
     );
   });
 
@@ -184,7 +184,7 @@ describe('authutil tests', () => {
     await auth.configAuthentication('https://registry.npmjs.org/');
     const contents = fs.readFileSync(rcFile, {encoding: 'utf8'});
     expect(contents).toBe(
-      `@otherscope:registry=NNN${os.EOL}//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}@myscope:registry=https://registry.npmjs.org/`
+      `@otherscope:registry=NNN${os.EOL}//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}@myscope:registry=https://registry.npmjs.org/${os.EOL}`
     );
   });
 
@@ -194,7 +194,7 @@ describe('authutil tests', () => {
     await auth.configAuthentication('https://registry.npmjs.org/');
     const contents = fs.readFileSync(rcFile, {encoding: 'utf8'});
     expect(contents).toBe(
-      `@otherscope:registry=MMM${os.EOL}//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}@myscope:registry=https://registry.npmjs.org/`
+      `@otherscope:registry=MMM${os.EOL}//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}${os.EOL}@myscope:registry=https://registry.npmjs.org/${os.EOL}`
     );
   });
 });

--- a/src/authutil.ts
+++ b/src/authutil.ts
@@ -44,6 +44,9 @@ function writeRegistryToFile(registryUrl: string, fileLocation: string) {
     registryUrl.replace(/(^\w+:|^)/, '') + ':_authToken=${NODE_AUTH_TOKEN}';
   const registryString = `${scope}registry=${registryUrl}`;
   newContents += `${authString}${os.EOL}${registryString}`;
+  if (newContents && !newContents.endsWith(os.EOL)) {
+    newContents += os.EOL;
+  }
   fs.writeFileSync(fileLocation, newContents);
   core.exportVariable('NPM_CONFIG_USERCONFIG', fileLocation);
   // Export empty node_auth_token if didn't exist so npm doesn't complain about not being able to find it


### PR DESCRIPTION
Add a newline at the end of the registry string in authutil, to ensure that it's a proper POSIX text file.

**Description:**

Had to add the newline myself, when adding more registries to npmrc.

```
    - name: Use Node.js 24.14.x
      uses: actions/setup-node@v6
      with:
        node-version: 24.14.x
        cache: 'pnpm'
        registry-url: 'https://registry.npmjs.org'
        
    - name: 'add bigcorp repo to .npmrc'
      run: |
        echo "" >> ${NPM_CONFIG_USERCONFIG} # <---- workaround for this bug
        echo "//npm.bigcorp.org/:_authToken=${NPM_TOKEN}" >> ${NPM_CONFIG_USERCONFIG}
        echo "@bigcorp:registry=https://npm.bigcorp.org/" >> ${NPM_CONFIG_USERCONFIG}
      shell: bash
      env:
        NPM_TOKEN: ${{ inputs.BIG_CORP_TOKEN }}
```
**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.