### PR TITLE
Add cache-write input for read-only cache mode

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
     default: true
   cache-dependency-path:
     description: 'Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc. Supports wildcards or a list of file names for caching multiple dependencies.'
+  cache-write:
+    description: 'Whether to save the cache at the end of the workflow. Set to false for cache read-only mode, useful for preventing cache poisoning from untrusted PR builds.'
+    default: true
   mirror:
     description: 'Used to specify an alternative mirror to download Node.js binaries from'
   mirror-token:

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -71532,6 +71532,11 @@ process.on('uncaughtException', e => {
 // Added early exit to resolve issue with slow post action step:
 async function run(earlyExit) {
     try {
+        const cacheWriteEnabled = core.getInput('cache-write');
+        if (cacheWriteEnabled === 'false') {
+            core.info('Cache write is disabled (read-only mode). Skipping cache save.');
+            return;
+        }
         const cacheLock = core.getState(constants_1.State.CachePackageManager);
         if (cacheLock) {
             await cachePackages(cacheLock);

--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -16,6 +16,12 @@ process.on('uncaughtException', e => {
 // Added early exit to resolve issue with slow post action step:
 export async function run(earlyExit?: boolean) {
   try {
+    const cacheWriteEnabled = core.getInput('cache-write');
+    if (cacheWriteEnabled === 'false') {
+      core.info('Cache write is disabled (read-only mode). Skipping cache save.');
+      return;
+    }
+
     const cacheLock = core.getState(State.CachePackageManager);
 
     if (cacheLock) {

--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -18,7 +18,9 @@ export async function run(earlyExit?: boolean) {
   try {
     const cacheWriteEnabled = core.getInput('cache-write');
     if (cacheWriteEnabled === 'false') {
-      core.info('Cache write is disabled (read-only mode). Skipping cache save.');
+      core.info(
+        'Cache write is disabled (read-only mode). Skipping cache save.'
+      );
       return;
     }
 


### PR DESCRIPTION
When using `cache` in workflows triggered by `pull_request`, there's no way to benefit from cached dependencies without also writing back to the cache at the end. This opens the door to cache poisoning, a malicious PR could push tainted packages into the cache that then get used by trusted runs on main.

This adds a `cache-write` input (defaults to `true`, fully backward compatible). When set to `false`, the post-step cache save is skipped so the action still restores deps from cache but never writes.

**Usage:**
```yaml
- uses: actions/setup-node@v6
  with:
    node-version: 20
    cache: npm
    cache-write: ${{ github.event_name != 'pull_request' }}
```

**What changed:**
- `action.yml` — new `cache-write` input
- `src/cache-save.ts` — early return when `cache-write` is `false`
- `dist/` — rebuilt

Pairs with similar PRs across setup-python, setup-go, setup-java, setup-dotnet for a consistent experience.