### PR TITLE
Add documentation for publishing to npm with Trusted Publisher (OIDC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ If the runner is not able to access github.com, any Nodejs versions requested du
  - [Publishing to npmjs and GPR with npm](docs/advanced-usage.md#publish-to-npmjs-and-gpr-with-npm)
  - [Publishing to npmjs and GPR with yarn](docs/advanced-usage.md#publish-to-npmjs-and-gpr-with-yarn)
  - [Using private packages](docs/advanced-usage.md#use-private-packages)
+ - [Publishing to npm with Trusted Publisher (OIDC)](docs/advanced-usage.md#publishing-to-npm-with-trusted-publisher-oidc)
  - [Using private mirror](docs/advanced-usage.md#use-private-mirror)
 
 ## Recommended permissions

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -475,6 +475,53 @@ To access private GitHub Packages within the same organization, go to "Manage Ac
 
 Please refer to the [Ensuring workflow access to your package - Configuring a package's access control and visibility](https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility#ensuring-workflow-access-to-your-package) for more details.
 
+## Publishing to npm with Trusted Publisher (OIDC)
+
+Npm supports Trusted Publishers, enabling packages to be published from GitHub Actions using OpenID Connect (OIDC) instead of long-lived npm tokens. This improves security by replacing static credentials with short-lived tokens, reducing the risk of credential leakage and simplifying authentication in CI/CD workflows.
+
+### Requirements
+
+Trusted publishing requires a compatible npm version:
+
+* **npm ≥ 11.5.1 (required)**
+* **Node.js 24 or newer (recommended)** — includes a compatible npm version by default
+
+> If npm is below 11.5.1, publishing will fail even if OIDC permissions are correctly configured.
+
+You must also configure a **Trusted Publisher** in npm for your package/scope that matches your GitHub repository and workflow (and optional environment, if used).
+
+### Example workflow
+
+```yaml
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm publish
+```
+
+### Important
+
+* `id-token: write` is required for OIDC authentication
+* `contents: read` is required for repository access
+* If a Trusted Publisher is configured with a GitHub Actions **environment**, it must also be set on the job (e.g. `environment: release`).
+
+OIDC authentication is handled automatically via GitHub’s identity token.
+
+> **Note**: If the Trusted Publisher configuration (GitHub owner/repo/workflow file, and optional environment) does not match the workflow run identity exactly, publishing may fail with **E404 Not Found** even if the package exists on npm.
+
+For more details, see the [npm Trusted Publishers documentation](https://docs.npmjs.com/trusted-publishers) and the [GitHub Actions OpenID Connect (OIDC) overview](https://docs.github.com/en/actions/concepts/security/openid-connect).
+
 ## Use private mirror
 
 It is possible to use a private mirror hosting Node.js binaries. This mirror must be a full mirror of the official Node.js distribution.

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -477,7 +477,7 @@ Please refer to the [Ensuring workflow access to your package - Configuring a pa
 
 ## Publishing to npm with Trusted Publisher (OIDC)
 
-Npm supports Trusted Publishers, enabling packages to be published from GitHub Actions using OpenID Connect (OIDC) instead of long-lived npm tokens. This improves security by replacing static credentials with short-lived tokens, reducing the risk of credential leakage and simplifying authentication in CI/CD workflows.
+npm supports Trusted Publishers, enabling packages to be published from GitHub Actions using OpenID Connect (OIDC) instead of long-lived npm tokens. This improves security by replacing static credentials with short-lived tokens, reducing the risk of credential leakage and simplifying authentication in CI/CD workflows.
 
 ### Requirements
 
@@ -516,7 +516,7 @@ You must also configure a **Trusted Publisher** in npm for your package/scope th
 * `contents: read` is required for repository access
 * If a Trusted Publisher is configured with a GitHub Actions **environment**, it must also be set on the job (e.g. `environment: release`).
 
-OIDC authentication is handled automatically via GitHub’s identity token.
+OIDC authentication is handled automatically via GitHub's identity token.
 
 > **Note**: If the Trusted Publisher configuration (GitHub owner/repo/workflow file, and optional environment) does not match the workflow run identity exactly, publishing may fail with **E404 Not Found** even if the package exists on npm.
 

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -495,7 +495,7 @@ You must also configure a **Trusted Publisher** in npm for your package/scope th
 ```yaml
     permissions:
       contents: read
-      id-token: write
+      id-token: write  # Required for OIDC
 
     steps:
       - uses: actions/checkout@v6
@@ -509,14 +509,6 @@ You must also configure a **Trusted Publisher** in npm for your package/scope th
       - run: npm run build --if-present
       - run: npm publish
 ```
-
-### Important
-
-* `id-token: write` is required for OIDC authentication
-* `contents: read` is required for repository access
-* If a Trusted Publisher is configured with a GitHub Actions **environment**, it must also be set on the job (e.g. `environment: release`).
-
-OIDC authentication is handled automatically via GitHub's identity token.
 
 > **Note**: If the Trusted Publisher configuration (GitHub owner/repo/workflow file, and optional environment) does not match the workflow run identity exactly, publishing may fail with **E404 Not Found** even if the package exists on npm.
 


### PR DESCRIPTION
**Description:**
This pull request updates the documentation to add guidance on publishing npm packages using Trusted Publisher (OIDC), which allows secure publishing from GitHub Actions without long-lived npm tokens. The changes clarify requirements, provide an example workflow, and link to relevant resources.

Documentation updates for npm Trusted Publisher (OIDC):

* Added a new section in `docs/advanced-usage.md` explaining how to publish to npm using Trusted Publisher (OIDC), including requirements, an example workflow, and important notes for configuration.
* Updated the `README.md` to include a link to the new Trusted Publisher (OIDC) documentation section.

**Related issue:**
https://github.com/actions/setup-node/issues/1445

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.