### PR TITLE
docs(links): replace redirected and stale URLs with current targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ See [action.yml](action.yml)
     # We recommend using a service account with the least permissions necessary. Also
     # when generating a new PAT, select the least scopes necessary.
     #
-    # [Learn more about creating and using encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)
+    # [Learn more about creating and using encrypted secrets](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets)
     #
     # Default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
     token: ''
@@ -223,7 +223,7 @@ jobs:
 
 ## Using `setup-node` on GHES
 
-`setup-node` comes pre-installed on the appliance with GHES if Actions is enabled. When dynamically downloading Nodejs distributions, `setup-node` downloads distributions from [`actions/node-versions`](https://github.com/actions/node-versions) on github.com (outside of the appliance). These calls to `actions/node-versions` are made via unauthenticated requests, which are limited to [60 requests per hour per IP](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting). If more requests are made within the time frame, then you will start to see rate-limit errors during downloading that looks like: `##[error]API rate limit exceeded for...`. After that error the action will try to download versions directly from the official site, but it also can have rate limit so it's better to put token.
+`setup-node` comes pre-installed on the appliance with GHES if Actions is enabled. When dynamically downloading Nodejs distributions, `setup-node` downloads distributions from [`actions/node-versions`](https://github.com/actions/node-versions) on github.com (outside of the appliance). These calls to `actions/node-versions` are made via unauthenticated requests, which are limited to [60 requests per hour per IP](https://docs.github.com/en/rest/using-the-rest-api/getting-started-with-the-rest-api?apiVersion=2026-03-10#rate-limiting). If more requests are made within the time frame, then you will start to see rate-limit errors during downloading that looks like: `##[error]API rate limit exceeded for...`. After that error the action will try to download versions directly from the official site, but it also can have rate limit so it's better to put token.
 
 To get a higher rate limit, you can [generate a personal access token on github.com](https://github.com/settings/tokens/new) and pass it as the `token` input for the action:
 

--- a/docs/adrs/0000-caching-dependencies.md
+++ b/docs/adrs/0000-caching-dependencies.md
@@ -56,4 +56,4 @@ steps:
 # Release process
 
 As soon as functionality is implemented, we will release minor update of action. No need to bump major version since there are no breaking changes for existing users.
-After that, we will update [starter-workflows](https://github.com/actions/starter-workflows/blob/main/ci/node.js.yml) and [GitHub Action documentation](https://docs.github.com/en/actions/guides/building-and-testing-nodejs#example-caching-dependencies).
+After that, we will update [starter-workflows](https://github.com/actions/starter-workflows/blob/main/ci/node.js.yml) and [GitHub Action documentation](https://docs.github.com/en/actions/tutorials/build-and-test-code/nodejs#example-caching-dependencies).

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -117,7 +117,7 @@ When using the `package.json` input, the action will look in the following field
 
 ## Architecture
 
-You can use any of the [supported operating systems](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners), and the compatible `architecture` can be selected using `architecture`. Values are `x86`, `x64`, `arm64`, `armv6l`, `armv7l`, `ppc64le`, `s390x` (not all of the architectures are available on all platforms).
+You can use any of the [supported operating systems](https://docs.github.com/en/actions/concepts/runners/github-hosted-runners), and the compatible `architecture` can be selected using `architecture`. Values are `x86`, `x64`, `arm64`, `armv6l`, `armv7l`, `ppc64le`, `s390x` (not all of the architectures are available on all platforms).
 
 When using `architecture`, `node-version` must be provided as well.
 ```yaml


### PR DESCRIPTION
## Summary
Replaces outdated and redirecting documentation links across markdown files with their current canonical URLs, and fixes a missing newline at the end of `feature_request.md`.

## Changes
- **`README.md`**: Updated two links:
  - Encrypted secrets reference: `help.github.com` → `docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets`
  - REST API rate-limiting: `rest/overview/resources-in-the-rest-api#rate-limiting` → `rest/using-the-rest-api/getting-started-with-the-rest-api?apiVersion=2026-03-10#rate-limiting`
- **`docs/advanced-usage.md`**: GitHub-hosted runners link updated from `using-github-hosted-runners/about-github-hosted-runners` → `concepts/runners/github-hosted-runners`
- **`docs/adrs/0000-caching-dependencies.md`**: Node.js build-and-test guide updated from `actions/guides/building-and-testing-nodejs` → `actions/tutorials/build-and-test-code/nodejs`, anchor preserved
- **`.github/ISSUE_TEMPLATE/feature_request.md`**: Added missing newline at end of file

## Motivation
Several documentation links had been moved as part of GitHub Docs site restructuring (`help.github.com` → `docs.github.com`, `guides/` →
`tutorials/`, `using-github-hosted-runners/` → `concepts/runners/`, REST API overview reorganisation). Leaving redirect chains in place
degrades link reliability and may break in the future if redirects are removed.

## Impact
- Documentation readers and contributors will land on the correct, up-to-date pages without following redirect hops.
- No functional code changes; no action inputs, outputs, or runtime behaviour are affected.
- Fully backward-compatible.

## Testing
All updated URLs were validated with `curl -sIL` to confirm HTTP 200 responses at the final destination before committing. No automated tests are required for documentation-only changes.

**Related issue:**
No issue is created as the change is related to documentation improvement only.

**Check list:**
- [X] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.