### PR TITLE
docs(action): document stable input and fix output/cache descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ See [action.yml](action.yml)
     # Default: false
     check-latest: false
 
+    # When true, only stable releases are matched when resolving LTS aliases and version
+    # manifest lookups. Set to false to allow pre-release builds.
+    # Default: true
+    stable: true
+
     # Target architecture for Node to use. Examples: x86, x64. Will use system architecture by default.
     # Default: ''. The action use system architecture by default
     architecture: ''

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   check-latest:
     description: 'Set this option if you want the action to check for the latest available version that satisfies the version spec.'
     default: false
+  stable:
+    description: 'When true, only stable releases are matched when resolving LTS aliases and version manifest lookups. Set to false to allow pre-release builds.'
+    default: true
   registry-url:
     description: 'Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN.'
   scope:
@@ -19,9 +22,9 @@ inputs:
     description: Used to pull node distributions from node-versions. Since there's a default, this is typically not supplied by the user. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
     default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
   cache:
-    description: 'Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm.'
+    description: 'Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm. The package manager must be pre-installed.'
   package-manager-cache:
-    description: 'Set to false to disable automatic caching. By default, caching is enabled when either devEngines.packageManager or the top-level packageManager field in package.json specifies npm as the package manager.'
+    description: 'Set to false to disable automatic caching. By default, caching is enabled when either devEngines.packageManager or the top-level packageManager field in package.json specifies npm as the package manager. Yarn and pnpm are not auto-detected; use the cache input instead.'
     default: true
   cache-dependency-path:
     description: 'Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc. Supports wildcards or a list of file names for caching multiple dependencies.'
@@ -33,9 +36,9 @@ inputs:
 #       escape valve for someone having issues or needing the absolute latest which isn't cached yet
 outputs:
   cache-hit:
-    description: 'A boolean value to indicate if a cache was hit.'
+    description: "A string 'true' if a cache entry was restored, 'false' otherwise. Only set when the cache or package-manager-cache feature is active."
   node-version:
-    description: 'The installed node version.'
+    description: 'The installed node version. Always set, including when no node-version input is provided.'
 runs:
   using: 'node24'
   main: 'dist/setup/index.js'


### PR DESCRIPTION
## Summary
Fixes several inaccuracies in `action.yml` input/output descriptions and documents the previously undiscoverable `stable` input that was already implemented but never exposed to users.

## Changes
- **`stable` input (new)** — Added to `action.yml` and the README usage block. Was already consumed by `main.ts` (`core.getInput('stable')`, default `true`) and passed to `official_builds.ts` for LTS alias resolution and manifest filtering. Without this entry, users had no way to know the input existed.
- **`cache-hit` output** — Corrected from "A boolean value" to a string `'true'`/`'false'`. `cache-restore.ts` calls `core.setOutput('cache-hit', Boolean(cacheKey))` which GitHub Actions serialises as a string. Also added that it is only populated when caching is active.
- **`node-version` output** — Added that it is always set. `printEnvDetailsAndSetOutput()` in `util.ts` runs unconditionally and calls `core.setOutput('node-version', ...)` even when no `node-version` input is provided.
- **`cache` input** — Added "The package manager must be pre-installed." The restore logic throws immediately if the tool is not found on the runner.
- **`package-manager-cache` input** — Appended that yarn and pnpm are not auto-detected; `getNameFromPackageManagerField()` only ever returns `'npm'`.

## Motivation
The `stable` input was silently accepted by the action for controlling whether pre-release builds satisfy LTS version specs, but was invisible in both `action.yml` and the README. Users who needed `stable: false` (e.g. to test against an RC build matching an LTS alias) had no documented way to know this was possible.

The output and cache description fixes close the gap between what the code actually does and what the documentation claims.

## Impact
- No behavior change — purely documentation.
- Backward compatible — `stable` defaults to `true`, matching the existing hardcoded fallback in `main.ts` (`core.getInput('stable') || 'true'`), so existing workflows are unaffected.
 
## Testing
Documentation-only change; no code paths were modified. Verified each description change against the corresponding source file (`main.ts`, `cache-restore.ts`, `util.ts`, `official_builds.ts`).

## Notes
- `registry-url` still incorrectly references "project level .npmrc and .yarnrc file" in both `action.yml` and README — the auth file is written to `RUNNER_TEMP` and no `.yarnrc` is touched. Left out of scope intentionally.

**Related issue:**
No issue is created as the change is related to documentation improvement only.

**Check list:**
- [X] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.