### PR TITLE
Only use `mirrorToken` in `getManifest` if it's provided

### DIFF
--- a/src/distributions/official_builds/official_builds.ts
+++ b/src/distributions/official_builds/official_builds.ts
@@ -84,7 +84,9 @@ export default class OfficialBuilds extends BaseDistribution {
         downloadPath = await tc.downloadTool(
           versionInfo.downloadUrl,
           undefined,
-          this.nodeInfo.mirror ? this.nodeInfo.mirrorToken : this.nodeInfo.auth
+          this.nodeInfo.mirror && this.nodeInfo.mirrorToken
+            ? this.nodeInfo.mirrorToken
+            : this.nodeInfo.auth
         );
 
         if (downloadPath) {
@@ -188,7 +190,9 @@ export default class OfficialBuilds extends BaseDistribution {
     return tc.getManifestFromRepo(
       'actions',
       'node-versions',
-      this.nodeInfo.mirror ? this.nodeInfo.mirrorToken : this.nodeInfo.auth,
+      this.nodeInfo.mirror && this.nodeInfo.mirrorToken
+        ? this.nodeInfo.mirrorToken
+        : this.nodeInfo.auth,
       'main'
     );
   }


### PR DESCRIPTION
**Description:**
When providing a `mirror`, but not a `mirrorToken` then `getManifest` will use the empty `mirrorToken` instead of any possible github token. This can lead to API Rate Limit exhaustion inadvertently.

The proposed fix is to only supply `mirrorToken` if it is actually set.

**Related issue:**
I couldn't find any directly related issues

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.