### PR TITLE
Explicitly disable caches in sensitive publish workflows

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -401,6 +401,7 @@ steps:
   with:
     node-version: '24.x'
     registry-url: 'https://registry.npmjs.org'
+    package-manager-cache: false # Prevent cache poisoning issues
 - run: npm ci
 - run: npm publish
   env:
@@ -408,6 +409,7 @@ steps:
 - uses: actions/setup-node@v6
   with:
     registry-url: 'https://npm.pkg.github.com'
+    package-manager-cache: false # Prevent cache poisoning issues
 - run: npm publish
   env:
     NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -421,6 +423,7 @@ steps:
   with:
     node-version: '24.x'
     registry-url: <registry url>
+    package-manager-cache: false # Prevent cache poisoning issues
 - run: yarn install --frozen-lockfile
 - run: yarn publish
   env:
@@ -428,6 +431,7 @@ steps:
 - uses: actions/setup-node@v6
   with:
     registry-url: 'https://npm.pkg.github.com'
+    package-manager-cache: false # Prevent cache poisoning issues
 - run: yarn publish
   env:
     NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -504,6 +508,7 @@ You must also configure a **Trusted Publisher** in npm for your package/scope th
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false # Prevent cache poisoning issues
 
       - run: npm ci
       - run: npm run build --if-present


### PR DESCRIPTION
**Description:**

Sensitive workflows like the Trusted Publishing workflow should explicitly disable cache to reduce supply chain risk due to cache poisoning. See recent hack: https://tanstack.com/blog/npm-supply-chain-compromise-postmortem

It would be better if that default was applied automatically, and not depending on various conditions that are not so easy to understand, so explicitly disabling this in the documentation is safer for now.

Automatic caching was afaik turned on by default in v5 in certain conditions. I think it's worth considering reverting that change and making caching opt-in, to have a more secure action by default, even if it's less performant.

Note that many people upgrade actions without looking at the changelog, using Dependabot. Default value changes like this can introduce vulnerabilities, so whatever the default is, explicitly disabling the cache for sensitive workflows remains a good idea IMHO.

Note that on README.md, there's already a disclaimer giving similar advice. However it's not easy to find and your Trusted Publishing docs don't even follow that recommendation:

<img width="1700" height="396" alt="CleanShot 2026-05-14 at 11 10 25@2x" src="https://github.com/user-attachments/assets/db04239b-3378-4986-b1de-08357fa6cba0" />

https://github.com/actions/setup-node#breaking-changes-in-v5

I believe all your documented examples should follow that recommendation, explicitly disable caching with `package-manager-cache: false`, and link to a canonical doc page explaining the security problem.

This PR is just to kickstart the discussion; there are probably other sensitive workflows you document that do not have `package-manager-cache: false`, and probably other official GitHub Actions whose docs show insecure examples.


**Related issue:**

See my comment here: https://github.com/actions/setup-node/issues/1445#issuecomment-4428351441


**Check list:**
- [X] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.