### PR TITLE
Remove dummy NODE_AUTH_TOKEN export

### DIFF
--- a/__tests__/authutil.test.ts
+++ b/__tests__/authutil.test.ts
@@ -118,6 +118,27 @@ describe('authutil tests', () => {
     expect(process.env.NODE_AUTH_TOKEN).toEqual('foobar');
   });
 
+  it('should not export NODE_AUTH_TOKEN if not set in environment', async () => {
+    const exportSpy = jest.spyOn(core, 'exportVariable');
+    delete process.env.NODE_AUTH_TOKEN;
+    await auth.configAuthentication('https://registry.npmjs.org/');
+    expect(fs.statSync(rcFile)).toBeDefined();
+    const rc = readRcFile(rcFile);
+    expect(rc['registry']).toBe('https://registry.npmjs.org/');
+    expect(exportSpy).not.toHaveBeenCalledWith(
+      'NODE_AUTH_TOKEN',
+      expect.anything()
+    );
+  });
+
+  it('should export NODE_AUTH_TOKEN if set to empty string', async () => {
+    const exportSpy = jest.spyOn(core, 'exportVariable');
+    process.env.NODE_AUTH_TOKEN = '';
+    await auth.configAuthentication('https://registry.npmjs.org/');
+    expect(fs.statSync(rcFile)).toBeDefined();
+    expect(exportSpy).toHaveBeenCalledWith('NODE_AUTH_TOKEN', '');
+  });
+
   it('configAuthentication should overwrite non-scoped with non-scoped', async () => {
     fs.writeFileSync(rcFile, 'registry=NNN');
     await auth.configAuthentication('https://registry.npmjs.org/');

--- a/src/authutil.ts
+++ b/src/authutil.ts
@@ -46,9 +46,8 @@ function writeRegistryToFile(registryUrl: string, fileLocation: string) {
   newContents += `${authString}${os.EOL}${registryString}`;
   fs.writeFileSync(fileLocation, newContents);
   core.exportVariable('NPM_CONFIG_USERCONFIG', fileLocation);
-  // Export empty node_auth_token if didn't exist so npm doesn't complain about not being able to find it
-  core.exportVariable(
-    'NODE_AUTH_TOKEN',
-    process.env.NODE_AUTH_TOKEN || 'XXXXX-XXXXX-XXXXX-XXXXX'
-  );
+  // Only export NODE_AUTH_TOKEN if explicitly provided by user
+  if (Object.prototype.hasOwnProperty.call(process.env, 'NODE_AUTH_TOKEN')) {
+    core.exportVariable('NODE_AUTH_TOKEN', process.env.NODE_AUTH_TOKEN);
+  }
 }


### PR DESCRIPTION
**Description:**
The action previously exported a dummy NODE_AUTH_TOKEN value (XXXXX-XXXXX-XXXXX-XXXXX) when no token was provided. While this didn't break OIDC flows, it could corrupt the user's .npmrc by injecting a non-functional token value into the environment, potentially causing confusing behavior during OIDC publish. This PR removes the dummy fallback and only exports NODE_AUTH_TOKEN when the user has explicitly set it.

**Related issue:**
https://github.com/actions/setup-node/issues/1440

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.