### PR TITLE
docs: Update caching recommendations to mitigate cache poisoning risks

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ steps:
 - uses: actions/setup-node@v6
   with:
     node-version: 24
+    package-manager-cache: false # Disable automatic npm caching if not required
 - run: npm ci
 - run: npm test
 ```
@@ -217,6 +218,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
+          package-manager-cache: false # Disable automatic npm caching if not required
       - run: npm ci
       - run: npm test
 ```
@@ -232,6 +234,7 @@ uses: actions/setup-node@v6
 with:
   token: ${{ secrets.GH_DOTCOM_TOKEN }}
   node-version: 24
+  package-manager-cache: false # Disable automatic npm caching if not required
 ```
 
 If the runner is not able to access github.com, any Nodejs versions requested during a workflow run must come from the runner's tool cache. See "[Setting up the tool cache on self-hosted runners without internet access](https://docs.github.com/en/enterprise-server@3.2/admin/github-actions/managing-access-to-actions-from-githubcom/setting-up-the-tool-cache-on-self-hosted-runners-without-internet-access)" for more information.

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -256,7 +256,7 @@ jobs:
       - run: npm test
 ```
 
-**Note:** Unlike nightly versions, which support version range specifiers, you must specify the exact version for a release candidate: `24.0.0-rc.4`.
+**Note**: Unlike nightly versions, which support version range specifiers, you must specify the exact version for a release candidate: `24.0.0-rc.4`.
 
 ## Caching packages data
 The action follows [actions/cache](https://github.com/actions/cache/blob/main/examples.md#node---npm) guidelines, and caches global cache on the machine instead of `node_modules`, so cache can be reused between different Node.js versions.
@@ -416,6 +416,7 @@ steps:
   with:
     node-version: '24.x'
     registry-url: 'https://registry.npmjs.org'
+    package-manager-cache: false  # Disable automatic npm dependency caching to reduce cache poisoning risk
 - run: npm ci
 - run: npm publish
   env:
@@ -423,6 +424,7 @@ steps:
 - uses: actions/setup-node@v6
   with:
     registry-url: 'https://npm.pkg.github.com'
+    package-manager-cache: false  # Disable automatic npm dependency caching to reduce cache poisoning risk
 - run: npm publish
   env:
     NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -505,6 +507,8 @@ Trusted publishing requires a compatible npm version:
 
 You must also configure a **Trusted Publisher** in npm for your package/scope that matches your GitHub repository and workflow (and optional environment, if used).
 
+> **Note**: Set `package-manager-cache: false` in publishing workflows because automatic npm caching can activate even without the `cache:` input, and a poisoned cache may expose credentials (including OIDC tokens) to attacker-controlled code.
+
 ### Example workflow
 
 ```yaml
@@ -519,6 +523,7 @@ You must also configure a **Trusted Publisher** in npm for your package/scope th
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false  # Disable automatic npm dependency caching to reduce cache poisoning risk
 
       - run: npm ci
       - run: npm run build --if-present

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -69,6 +69,7 @@ steps:
   with:
     node-version: '24'
     check-latest: true
+    package-manager-cache: false # Disable automatic npm caching if not required
 - run: npm ci
 - run: npm test
 ```
@@ -86,6 +87,7 @@ steps:
 - uses: actions/setup-node@v6
   with:
     node-version-file: '.nvmrc'
+    package-manager-cache: false # Disable automatic npm caching if not required
 - run: npm ci
 - run: npm test
 ```
@@ -131,6 +133,7 @@ jobs:
         with:
           node-version: '24'
           architecture: 'x64' # optional, x64 or x86. If not specified, x64 will be used by default
+          package-manager-cache: false # Disable automatic npm caching if not required
       - run: npm ci
       - run: npm test
 ```
@@ -151,6 +154,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '24.0.0-v8-canary' # it will install the latest v8 canary release for node 24.0.0
+          package-manager-cache: false # Disable automatic npm caching if not required
       - run: npm ci
       - run: npm test
 ```
@@ -166,6 +170,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '24-v8-canary' # it will install the latest v8 canary release for node 24
+          package-manager-cache: false # Disable automatic npm caching if not required
       - run: npm ci
       - run: npm test
 ```
@@ -182,6 +187,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 'v24.0.0-v8-canary2025030537242e55ac'
+          package-manager-cache: false # Disable automatic npm caching if not required
       - run: npm ci
       - run: npm test
 ```
@@ -202,6 +208,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '24-nightly' # it will install the latest nightly release for node 24
+          package-manager-cache: false # Disable automatic npm caching if not required
       - run: npm ci
       - run: npm test
 ```
@@ -218,6 +225,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '24.0.0-nightly' # it will install the latest nightly release for node 24.0.0
+          package-manager-cache: false # Disable automatic npm caching if not required
       - run: npm ci
       - run: npm test
 ```
@@ -234,6 +242,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '24.0.0-nightly202505066102159fa1'
+          package-manager-cache: false # Disable automatic npm caching if not required
       - run: npm ci
       - run: npm test
 ```
@@ -252,6 +261,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '24.0.0-rc.4'
+          package-manager-cache: false # Disable automatic npm caching if not required
       - run: npm ci
       - run: npm test
 ```
@@ -344,6 +354,7 @@ steps:
   uses: actions/setup-node@v6
   with:
     node-version: '24'
+    package-manager-cache: false # Disable automatic npm caching if not required
 
 - name: Normalize runner architecture
   shell: bash
@@ -404,6 +415,7 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
           architecture: ${{ matrix.architecture }}
+          package-manager-cache: false # Disable automatic npm caching if not required
       - run: npm ci
       - run: npm test
 ```
@@ -416,7 +428,7 @@ steps:
   with:
     node-version: '24.x'
     registry-url: 'https://registry.npmjs.org'
-    package-manager-cache: false  # Disable automatic npm dependency caching to reduce cache poisoning risk
+    package-manager-cache: false # Disable automatic npm dependency caching to reduce cache poisoning risk
 - run: npm ci
 - run: npm publish
   env:
@@ -424,7 +436,7 @@ steps:
 - uses: actions/setup-node@v6
   with:
     registry-url: 'https://npm.pkg.github.com'
-    package-manager-cache: false  # Disable automatic npm dependency caching to reduce cache poisoning risk
+    package-manager-cache: false # Disable automatic npm dependency caching to reduce cache poisoning risk
 - run: npm publish
   env:
     NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -438,6 +450,7 @@ steps:
   with:
     node-version: '24.x'
     registry-url: <registry url>
+    package-manager-cache: false # Disable automatic npm dependency caching to reduce cache poisoning risk
 - run: yarn install --frozen-lockfile
 - run: yarn publish
   env:
@@ -445,6 +458,7 @@ steps:
 - uses: actions/setup-node@v6
   with:
     registry-url: 'https://npm.pkg.github.com'
+    package-manager-cache: false # Disable automatic npm dependency caching to reduce cache poisoning risk
 - run: yarn publish
   env:
     NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -458,6 +472,7 @@ steps:
   with:
     node-version: '24.x'
     registry-url: 'https://registry.npmjs.org'
+    package-manager-cache: false # Disable automatic npm dependency caching to reduce cache poisoning risk
 # Skip post-install scripts here, as a malicious
 # script could steal NODE_AUTH_TOKEN.
 - run: npm ci --ignore-scripts
@@ -477,6 +492,7 @@ steps:
 - uses: actions/setup-node@v6
   with:
     node-version: '24.x'
+    package-manager-cache: false # Disable automatic npm dependency caching to reduce cache poisoning risk
 - name: Setup .yarnrc.yml
   run: |
     yarn config set npmScopes.my-org.npmRegistryServer "https://npm.pkg.github.com"
@@ -507,7 +523,7 @@ Trusted publishing requires a compatible npm version:
 
 You must also configure a **Trusted Publisher** in npm for your package/scope that matches your GitHub repository and workflow (and optional environment, if used).
 
-> **Note**: Set `package-manager-cache: false` in publishing workflows because automatic npm caching can activate even without the `cache:` input, and a poisoned cache may expose credentials (including OIDC tokens) to attacker-controlled code.
+> **Note**: In publishing workflows, set `package-manager-cache: false` because setup-node enables npm caching automatically when `package.json` specifies npm via `packageManager` or `devEngines.packageManager` (see [Running without a lockfile](#running-without-a-lockfile)), and a poisoned cache may expose credentials (including OIDC tokens) to attacker-controlled code.
 
 ### Example workflow
 
@@ -523,7 +539,7 @@ You must also configure a **Trusted Publisher** in npm for your package/scope th
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-          package-manager-cache: false  # Disable automatic npm dependency caching to reduce cache poisoning risk
+          package-manager-cache: false # Disable automatic npm dependency caching to reduce cache poisoning risk
 
       - run: npm ci
       - run: npm run build --if-present
@@ -547,4 +563,5 @@ The token will be passed in the `Authorization` header.
     node-version: '24.x'
     mirror: 'https://nodejs.org/dist'
     mirror-token: 'your-mirror-token'
+    cache-package-manager: false # Disable automatic npm caching if not required
 ```


### PR DESCRIPTION
**Description:**
This pull request updates the documentation in `README.md` and `docs/advanced-usage.md` to consistently recommend disabling automatic npm package manager caching when it is not required, especially in publishing workflows. This helps reduce the risk of cache poisoning, which could potentially expose sensitive credentials. The changes add the `package-manager-cache: false` option to relevant `actions/setup-node@v6` usage examples and provide additional context and recommendations regarding caching and security.

**Related issue:**
https://github.com/actions/setup-node/issues/1445

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.