### PR TITLE
Add cache-primary-key and cache-matched-key as outputs

### DIFF
--- a/__tests__/cache-restore.test.ts
+++ b/__tests__/cache-restore.test.ts
@@ -137,6 +137,7 @@ describe('cache-restore', () => {
     ] as const)(
       'restored dependencies for %s',
       async (packageManager, toolVersion, fileHash) => {
+        const expectedCacheKey = `node-cache-${platform}-${arch}-${packageManager}-${fileHash}`;
         // Set workspace to the appropriate fixture folder
         setWorkspaceFor(packageManager);
         getCommandOutputSpy.mockImplementation((command: string) => {
@@ -150,12 +151,20 @@ describe('cache-restore', () => {
         await restoreCache(packageManager, '');
         expect(hashFilesSpy).toHaveBeenCalled();
         expect(infoSpy).toHaveBeenCalledWith(
-          `Cache restored from key: node-cache-${platform}-${arch}-${packageManager}-${fileHash}`
+          `Cache restored from key: ${expectedCacheKey}`
         );
         expect(infoSpy).not.toHaveBeenCalledWith(
           `${packageManager} cache is not found`
         );
         expect(setOutputSpy).toHaveBeenCalledWith('cache-hit', true);
+        expect(setOutputSpy).toHaveBeenCalledWith(
+          'cache-primary-key',
+          expectedCacheKey
+        );
+        expect(setOutputSpy).toHaveBeenCalledWith(
+          'cache-matched-key',
+          expectedCacheKey
+        );
       }
     );
   });
@@ -169,6 +178,7 @@ describe('cache-restore', () => {
     ] as const)(
       'dependencies are changed %s',
       async (packageManager, toolVersion, fileHash) => {
+        const expectedCacheKey = `node-cache-${platform}-${arch}-${packageManager}-${fileHash}`;
         // Set workspace to the appropriate fixture folder
         setWorkspaceFor(packageManager);
         getCommandOutputSpy.mockImplementation((command: string) => {
@@ -186,6 +196,14 @@ describe('cache-restore', () => {
           `${packageManager} cache is not found`
         );
         expect(setOutputSpy).toHaveBeenCalledWith('cache-hit', false);
+        expect(setOutputSpy).toHaveBeenCalledWith(
+          'cache-primary-key',
+          expectedCacheKey
+        );
+        expect(setOutputSpy).toHaveBeenCalledWith(
+          'cache-matched-key',
+          undefined
+        );
       }
     );
   });

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
 outputs:
   cache-hit:
     description: 'A boolean value to indicate if a cache was hit.'
+  cache-primary-key:
+    description: 'The key used for the cache.'
+  cache-matched-key:
+    description: 'The key used for the cache that resulted in a cache hit.'
   node-version:
     description: 'The installed node version.'
 runs:

--- a/action.yml
+++ b/action.yml
@@ -35,9 +35,9 @@ outputs:
   cache-hit:
     description: 'A boolean value to indicate if a cache was hit.'
   cache-primary-key:
-    description: 'The key used for the cache.'
+    description: 'The key used to restore and save the cache.'
   cache-matched-key:
-    description: 'The key used for the cache that resulted in a cache hit.'
+    description: 'The key of the cache that was restored. Empty when no cache is found.'
   node-version:
     description: 'The installed node version.'
 runs:

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -57021,6 +57021,7 @@ const restoreCache = async (packageManager, cacheDependencyPath) => {
     const primaryKey = `${keyPrefix}-${fileHash}`;
     core.debug(`primary key is ${primaryKey}`);
     core.saveState(constants_1.State.CachePrimaryKey, primaryKey);
+    core.setOutput('cache-primary-key', primaryKey);
     const isManagedByYarnBerry = await (0, cache_utils_1.repoHasYarnBerryManagedDependencies)(packageManagerInfo, cacheDependencyPath);
     let cacheKey;
     if (isManagedByYarnBerry) {
@@ -57031,6 +57032,8 @@ const restoreCache = async (packageManager, cacheDependencyPath) => {
         cacheKey = await cache.restoreCache(cachePaths, primaryKey);
     }
     core.setOutput('cache-hit', Boolean(cacheKey));
+    core.setOutput('cache-matched-key', cacheKey);
+    core.debug(`cache-matched-key is ${cacheKey}`);
     if (!cacheKey) {
         core.info(`${packageManager} cache is not found`);
         return;

--- a/src/cache-restore.ts
+++ b/src/cache-restore.ts
@@ -45,6 +45,7 @@ export const restoreCache = async (
   core.debug(`primary key is ${primaryKey}`);
 
   core.saveState(State.CachePrimaryKey, primaryKey);
+  core.setOutput('cache-primary-key', primaryKey);
 
   const isManagedByYarnBerry = await repoHasYarnBerryManagedDependencies(
     packageManagerInfo,
@@ -61,6 +62,8 @@ export const restoreCache = async (
   }
 
   core.setOutput('cache-hit', Boolean(cacheKey));
+  core.setOutput('cache-matched-key', cacheKey);
+  core.debug(`cache-matched-key is ${cacheKey}`);
 
   if (!cacheKey) {
     core.info(`${packageManager} cache is not found`);


### PR DESCRIPTION
**Description:**
Adds cache-primary-key and cache-matched-key as outputs

**Related issue:**
https://github.com/actions/setup-node/issues/1129

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.