### PR TITLE
Update workflow pins and migrate Node matrices to modern versions

### DIFF
--- a/.github/workflows/e2e-cache.yml
+++ b/.github/workflows/e2e-cache.yml
@@ -18,10 +18,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-large]
-        node-version: [20, 22, 24]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
+        node-version: [22, 24, 26]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Clean global cache
         run: npm cache clean --force
       - name: Setup Node
@@ -41,14 +41,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-large]
-        node-version: [20, 22, 24]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
+        node-version: [22, 24, 26]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 6.10.0
+          version: 10
       - name: Generate pnpm file
         run: pnpm install
       - name: Remove dependencies
@@ -74,10 +74,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-large]
-        node-version: [20, 22, 24]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
+        node-version: [22, 24, 26]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Yarn version
         run: yarn --version
       - name: Generate yarn file
@@ -106,10 +106,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-large]
-        node-version: [20, 22, 24]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
+        node-version: [22, 24, 26]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Update yarn
         run: yarn set version 3.6.4
       - name: Yarn version
@@ -139,11 +139,11 @@ jobs:
     name: Test yarn subprojects
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24, 26]
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: prepare sub-projects
         run: __tests__/prepare-yarn-subprojects.sh yarn1
@@ -166,11 +166,11 @@ jobs:
     name: Test yarn subprojects all locally managed
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24, 26]
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: prepare sub-projects
         run: __tests__/prepare-yarn-subprojects.sh keepcache keepcache
@@ -193,11 +193,11 @@ jobs:
     name: Test yarn subprojects some locally managed
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24, 26]
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: prepare sub-projects
         run: __tests__/prepare-yarn-subprojects.sh global
@@ -220,11 +220,11 @@ jobs:
     name: Test yarn subprojects managed by git
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24, 26]
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: prepare sub-projects
         run: /bin/bash __tests__/prepare-yarn-subprojects.sh keepcache
@@ -250,10 +250,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-large]
-        node-version: [20, 22, 24]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
+        node-version: [22, 24, 26]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Create package.json with packageManager field
         run: |
           echo '{ "name": "test-project", "version": "1.0.0", "packageManager": "npm@8.0.0" }' > package.json
@@ -275,10 +275,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-large]
-        node-version: [20, 22, 24]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
+        node-version: [22, 24, 26]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Create package.json with devEngines field
         run: |
           echo '{

--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -25,7 +25,7 @@ jobs:
     env:
       https_proxy: http://squid-proxy:3128
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Clear tool cache
         run: rm -rf $RUNNER_TOOL_CACHE/*
       - name: Setup node 24
@@ -41,7 +41,7 @@ jobs:
       https_proxy: http://no-such-proxy:3128
       no_proxy: api.github.com,github.com,nodejs.org,registry.npmjs.org,*.s3.amazonaws.com,s3.amazonaws.com
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Clear tool cache
         run: rm -rf $RUNNER_TOOL_CACHE/*
       - name: Setup node 24

--- a/.github/workflows/publish-immutable-actions.yml
+++ b/.github/workflows/publish-immutable-actions.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checking out
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Publish
         id: publish
-        uses: actions/publish-immutable-action@v0.0.4
+        uses: actions/publish-immutable-action@4bc8754ffc40f27910afb20287dbbbb675a4e978 # v0.0.4

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-15-intel]
-        node-version: [lts/iron, lts/*, lts/-1]
+        node-version: [lts/*, lts/-1]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Node

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -61,7 +61,7 @@ jobs:
           [
             '26-v8-canary',
             '26.0.0-v8-canary',
-            'v26.0.0-v8-canary20251016054584e5cf'
+            '26.0.0-v8-canary20251016054584e5cf'
           ]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -251,10 +251,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Setup node 26 x86 from dist
+      - name: Setup node 22 x86 from dist
         uses: ./
         with:
-          node-version: '26'
+          node-version: '22'
           architecture: 'x86'
       - name: Verify node
         run: __tests__/verify-arch.sh "ia32"

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -17,10 +17,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-large]
-        node-version: [20, 22, 24]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
+        node-version: [22, 24, 26]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Node
         uses: ./
         with:
@@ -34,10 +34,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest-large]
-        node-version: [lts/dubnium, lts/erbium, lts/fermium, lts/*, lts/-1]
+        os: [ubuntu-latest, windows-latest, macos-15-intel]
+        node-version: [lts/iron, lts/*, lts/-1]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Node
         uses: ./
         with:
@@ -56,15 +56,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-large]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
         node-version:
           [
-            '20-v8-canary',
-            '20.0.0-v8-canary',
-            '20.0.0-v8-canary20221101e50e45c9f8'
+            '26-v8-canary',
+            '26.0.0-v8-canary',
+            'v26.0.0-v8-canary20251016054584e5cf'
           ]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Node
         uses: ./
         with:
@@ -81,10 +81,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-large]
-        node-version: [20-nightly, 25-nightly, 24.0.0-nightly]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
+        node-version: [26-nightly, 25-nightly, 24.0.0-nightly]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Node
         uses: ./
         with:
@@ -101,10 +101,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-large]
-        node-version: [20.0.0-rc.1, 22.14.0-rc.1, 24.0.0-rc.4]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
+        node-version: [26.0.0-rc.1, 22.14.0-rc.1, 24.0.0-rc.4]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Node
         uses: ./
         with:
@@ -121,10 +121,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-large]
-        node-version: [20.10.0, 22.0.0, 24.9.0]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
+        node-version: [26.5.0, 22.0.0, 24.9.0]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Node
         uses: ./
         with:
@@ -138,10 +138,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-large]
-        node-version: [20, 22, 24]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
+        node-version: [22, 24, 26]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Node and check latest
         uses: ./
         with:
@@ -156,11 +156,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-large]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
         node-version-file:
           [.nvmrc, .tool-versions, .tool-versions-node, package.json]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup node from node version file
         uses: ./
         with:
@@ -175,22 +175,22 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup node from node version file
         uses: ./
         with:
           node-version-file: '__tests__/data/package-dev-engines.json'
       - name: Verify node
-        run: __tests__/verify-node.sh 20
+        run: __tests__/verify-node.sh 26
 
   version-file-volta:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-large]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup node from node version file
         uses: ./
         with:
@@ -203,9 +203,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-large]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup node from node version file
         uses: ./
         with:
@@ -218,10 +218,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-large]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
         node-version: [21, 23]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Node from dist
         uses: ./
         with:
@@ -235,9 +235,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest-large]
+        os: [ubuntu-latest, windows-latest, macos-15-intel]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # test old versions which didn't have npm and layout different
       - name: Setup node 0.12.18 from dist
         uses: ./
@@ -250,11 +250,11 @@ jobs:
   arch:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
-      - name: Setup node 20 x86 from dist
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Setup node 26 x86 from dist
         uses: ./
         with:
-          node-version: '20'
+          node-version: '26'
           architecture: 'x86'
       - name: Verify node
         run: __tests__/verify-arch.sh "ia32"
@@ -265,7 +265,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-large]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
         node-version: [current, latest, node]
     steps:
       - name: Get node version
@@ -274,7 +274,7 @@ jobs:
           echo "LATEST_NODE_VERSION=$latestNodeVersion" >> $GITHUB_OUTPUT
         id: version
         shell: bash
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Node
         uses: ./
         with:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See [action.yml](action.yml)
 
 <!-- start usage -->
 ```yaml
-- uses: actions/setup-node@v6
+- uses: actions/setup-node@v7
   with:
     # Version Spec of the version to use in SemVer notation.
     # It also admits such aliases as lts/*, latest, nightly and canary builds
@@ -120,7 +120,7 @@ See [action.yml](action.yml)
 ```yaml
 steps:
 - uses: actions/checkout@v6
-- uses: actions/setup-node@v6
+- uses: actions/setup-node@v7
   with:
     node-version: 24
     package-manager-cache: false # Disable automatic npm caching if not required
@@ -170,7 +170,7 @@ See the examples of using cache for `yarn`/`pnpm` and `cache-dependency-path` in
 ```yaml
 steps:
 - uses: actions/checkout@v6
-- uses: actions/setup-node@v6
+- uses: actions/setup-node@v7
   with:
     node-version: 24
     cache: 'npm'
@@ -183,7 +183,7 @@ steps:
 ```yaml
 steps:
 - uses: actions/checkout@v6
-- uses: actions/setup-node@v6
+- uses: actions/setup-node@v7
   with:
     node-version: 24
     cache: 'npm'
@@ -199,7 +199,7 @@ This behavior is controlled by the `package-manager-cache` input, which defaults
 ```yaml
 steps:
 - uses: actions/checkout@v6
-- uses: actions/setup-node@v6
+- uses: actions/setup-node@v7
   with:
     package-manager-cache: false
 - run: npm ci
@@ -219,7 +219,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
           package-manager-cache: false # Disable automatic npm caching if not required
@@ -234,7 +234,7 @@ jobs:
 To get a higher rate limit, you can [generate a personal access token on github.com](https://github.com/settings/tokens/new) and pass it as the `token` input for the action:
 
 ```yaml
-uses: actions/setup-node@v6
+uses: actions/setup-node@v7
 with:
   token: ${{ secrets.GH_DOTCOM_TOKEN }}
   node-version: 24

--- a/__tests__/data/package-dev-engines.json
+++ b/__tests__/data/package-dev-engines.json
@@ -5,7 +5,7 @@
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": "^20"
+      "version": "^26"
     }
   }
 }

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -296,7 +296,7 @@ steps:
 
 steps:
 - uses: actions/checkout@v6
-- uses: pnpm/action-setup@v4
+- uses: pnpm/action-setup@v6
   with:
     version: 10
 - uses: actions/setup-node@v7

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -46,7 +46,7 @@ To run without a lockfile:
 ```yaml
 steps:
 - uses: actions/checkout@v6
-- uses: actions/setup-node@v6
+- uses: actions/setup-node@v7
   with:
     node-version: '24'
     package-manager-cache: false # Explicitly disable caching if you don't have a lockfile
@@ -65,7 +65,7 @@ If `check-latest` is set to `true`, the action first checks if the cached versio
 ```yaml
 steps:
 - uses: actions/checkout@v6
-- uses: actions/setup-node@v6
+- uses: actions/setup-node@v7
   with:
     node-version: '24'
     check-latest: true
@@ -84,7 +84,7 @@ See [supported version syntax](https://github.com/actions/setup-node#supported-v
 ```yaml
 steps:
 - uses: actions/checkout@v6
-- uses: actions/setup-node@v6
+- uses: actions/setup-node@v7
   with:
     node-version-file: '.nvmrc'
     package-manager-cache: false # Disable automatic npm caching if not required
@@ -129,7 +129,7 @@ jobs:
     name: Node sample
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '24'
           architecture: 'x64' # optional, x64 or x86. If not specified, x64 will be used by default
@@ -151,7 +151,7 @@ jobs:
     name: Node sample
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '24.0.0-v8-canary' # it will install the latest v8 canary release for node 24.0.0
           package-manager-cache: false # Disable automatic npm caching if not required
@@ -167,7 +167,7 @@ jobs:
     name: Node sample
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '24-v8-canary' # it will install the latest v8 canary release for node 24
           package-manager-cache: false # Disable automatic npm caching if not required
@@ -184,7 +184,7 @@ jobs:
     name: Node sample
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 'v24.0.0-v8-canary2025030537242e55ac'
           package-manager-cache: false # Disable automatic npm caching if not required
@@ -205,7 +205,7 @@ jobs:
     name: Node sample
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '24-nightly' # it will install the latest nightly release for node 24
           package-manager-cache: false # Disable automatic npm caching if not required
@@ -222,7 +222,7 @@ jobs:
     name: Node sample
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '24.0.0-nightly' # it will install the latest nightly release for node 24.0.0
           package-manager-cache: false # Disable automatic npm caching if not required
@@ -239,7 +239,7 @@ jobs:
     name: Node sample
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '24.0.0-nightly202505066102159fa1'
           package-manager-cache: false # Disable automatic npm caching if not required
@@ -258,7 +258,7 @@ jobs:
     name: Node sample
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '24.0.0-rc.4'
           package-manager-cache: false # Disable automatic npm caching if not required
@@ -277,7 +277,7 @@ Yarn caching handles both Yarn Classic (v1) and Yarn Berry (v2, v3, v4+).
 ```yaml
 steps:
 - uses: actions/checkout@v6
-- uses: actions/setup-node@v6
+- uses: actions/setup-node@v7
   with:
     node-version: '24'
     cache: 'yarn'
@@ -299,7 +299,7 @@ steps:
 - uses: pnpm/action-setup@v4
   with:
     version: 10
-- uses: actions/setup-node@v6
+- uses: actions/setup-node@v7
   with:
     node-version: '24'
     cache: 'pnpm'
@@ -315,7 +315,7 @@ steps:
 ```yaml
 steps:
 - uses: actions/checkout@v6
-- uses: actions/setup-node@v6
+- uses: actions/setup-node@v7
   with:
     node-version: '24'
     cache: 'npm'
@@ -328,7 +328,7 @@ steps:
 ```yaml
 steps:
 - uses: actions/checkout@v6
-- uses: actions/setup-node@v6
+- uses: actions/setup-node@v7
   with:
     node-version: '24'
     cache: 'npm'
@@ -351,7 +351,7 @@ steps:
 #     version: 10
 
 - name: Setup Node.js
-  uses: actions/setup-node@v6
+  uses: actions/setup-node@v7
   with:
     node-version: '24'
     package-manager-cache: false # Disable automatic npm caching if not required
@@ -397,9 +397,9 @@ jobs:
           - macos-latest
           - windows-latest
         node_version:
-          - 20
           - 22
           - 24
+          - 26
         architecture:
           - x64
         # an extra windows-x86 run:
@@ -411,7 +411,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node_version }}
           architecture: ${{ matrix.architecture }}
@@ -424,7 +424,7 @@ jobs:
 ```yaml
 steps:
 - uses: actions/checkout@v6
-- uses: actions/setup-node@v6
+- uses: actions/setup-node@v7
   with:
     node-version: '24.x'
     registry-url: 'https://registry.npmjs.org'
@@ -433,7 +433,7 @@ steps:
 - run: npm publish
   env:
     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-- uses: actions/setup-node@v6
+- uses: actions/setup-node@v7
   with:
     registry-url: 'https://npm.pkg.github.com'
     package-manager-cache: false # Disable automatic npm dependency caching to reduce cache poisoning risk
@@ -446,7 +446,7 @@ steps:
 ```yaml
 steps:
 - uses: actions/checkout@v6
-- uses: actions/setup-node@v6
+- uses: actions/setup-node@v7
   with:
     node-version: '24.x'
     registry-url: <registry url>
@@ -455,7 +455,7 @@ steps:
 - run: yarn publish
   env:
     NODE_AUTH_TOKEN: ${{ secrets.YARN_TOKEN }}
-- uses: actions/setup-node@v6
+- uses: actions/setup-node@v7
   with:
     registry-url: 'https://npm.pkg.github.com'
     package-manager-cache: false # Disable automatic npm dependency caching to reduce cache poisoning risk
@@ -468,7 +468,7 @@ steps:
 ```yaml
 steps:
 - uses: actions/checkout@v6
-- uses: actions/setup-node@v6
+- uses: actions/setup-node@v7
   with:
     node-version: '24.x'
     registry-url: 'https://registry.npmjs.org'
@@ -489,7 +489,7 @@ Below you can find a sample "Setup .yarnrc.yml" step, that is going to allow you
 ```yaml
 steps:
 - uses: actions/checkout@v6
-- uses: actions/setup-node@v6
+- uses: actions/setup-node@v7
   with:
     node-version: '24.x'
     package-manager-cache: false # Disable automatic npm dependency caching to reduce cache poisoning risk
@@ -535,7 +535,7 @@ You must also configure a **Trusted Publisher** in npm for your package/scope th
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -558,7 +558,7 @@ It is possible to specify a token to authenticate with the mirror using the `mir
 The token will be passed in the `Authorization` header.
 
 ```yaml
-- uses: actions/setup-node@v6
+- uses: actions/setup-node@v7
   with:
     node-version: '24.x'
     mirror: 'https://nodejs.org/dist'


### PR DESCRIPTION
**Description:**
Update workflow pins and migrate Node matrices to modern versions:
- pin actions/checkout to (v7.0.0)
- pin pnpm/action-setup to (v6.0.9)
- remove EOL versions
- replace macos-latest-large with macos-15-intel in workflow matrices

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.