### PR TITLE
fix: parse comments in .nvmrc files

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -216,6 +216,35 @@ describe('main tests', () => {
 
       expect(util.getNodeVersionFromFile('file')).toBe(expected);
     });
+
+    each`
+      name                                      | contents                                                       | expected
+      ${'ignores blank lines and comments'}     | ${'# use the version below\n\n  20.16.0 # maintenance release\n'} | ${'20.16.0'}
+      ${'strips an inline comment'}             | ${'v20.16.0 # maintenance release'}                            | ${'20.16.0'}
+      ${'preserves an alias before a comment'}  | ${'lts/* # use the latest LTS'}                                | ${'lts/*'}
+      ${'rejects a comment-only file'}          | ${'# comment only'}                                            | ${null}
+      ${'rejects comments and whitespace only'} | ${'#\r\n  # another comment\r\n'}                            | ${null}
+    `.it('$name', ({contents, expected}: any) => {
+      const existsSpy = jest.spyOn(fs, 'existsSync');
+      existsSpy.mockImplementation(() => true);
+
+      const readFileSpy = jest.spyOn(fs, 'readFileSync');
+      readFileSpy.mockImplementation(() => contents);
+
+      expect(util.getNodeVersionFromFile('.nvmrc')).toBe(expected);
+    });
+
+    it('preserves .tool-versions parsing', () => {
+      const existsSpy = jest.spyOn(fs, 'existsSync');
+      existsSpy.mockImplementation(() => true);
+
+      const readFileSpy = jest.spyOn(fs, 'readFileSync');
+      readFileSpy.mockImplementation(
+        () => 'ruby 3.3.0\nnodejs 20.16.0\npython 3.12.0'
+      );
+
+      expect(util.getNodeVersionFromFile('.tool-versions')).toBe('20.16.0');
+    });
   });
 
   describe('printEnvDetailsAndSetOutput', () => {

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -92709,8 +92709,19 @@ function getNodeVersionFromFile(versionFilePath) {
     catch {
         core.info('Node version file is not JSON file');
     }
-    const found = contents.match(/^(?:node(js)?\s+)?v?(?<version>[^\s]+)$/m);
-    return found?.groups?.version ?? contents.trim();
+    let versionFileContents = contents;
+    if (path.basename(versionFilePath) === '.nvmrc') {
+        versionFileContents = contents
+            .split(/\r?\n/)
+            .map(line => line.replace(/#.*/, '').trim())
+            .filter(Boolean)
+            .join('\n');
+        if (!versionFileContents) {
+            return null;
+        }
+    }
+    const found = versionFileContents.match(/^(?:node(js)?\s+)?v?(?<version>[^\s]+)$/m);
+    return found?.groups?.version ?? versionFileContents.trim();
 }
 async function printEnvDetailsAndSetOutput() {
     core.startGroup('Environment details');

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -98103,8 +98103,19 @@ function getNodeVersionFromFile(versionFilePath) {
     catch {
         core_info('Node version file is not JSON file');
     }
-    const found = contents.match(/^(?:node(js)?\s+)?v?(?<version>[^\s]+)$/m);
-    return found?.groups?.version ?? contents.trim();
+    let versionFileContents = contents;
+    if (external_path_default().basename(versionFilePath) === '.nvmrc') {
+        versionFileContents = contents
+            .split(/\r?\n/)
+            .map(line => line.replace(/#.*/, '').trim())
+            .filter(Boolean)
+            .join('\n');
+        if (!versionFileContents) {
+            return null;
+        }
+    }
+    const found = versionFileContents.match(/^(?:node(js)?\s+)?v?(?<version>[^\s]+)$/m);
+    return found?.groups?.version ?? versionFileContents.trim();
 }
 async function printEnvDetailsAndSetOutput() {
     startGroup('Environment details');

--- a/src/util.ts
+++ b/src/util.ts
@@ -68,8 +68,24 @@ export function getNodeVersionFromFile(versionFilePath: string): string | null {
     core.info('Node version file is not JSON file');
   }
 
-  const found = contents.match(/^(?:node(js)?\s+)?v?(?<version>[^\s]+)$/m);
-  return found?.groups?.version ?? contents.trim();
+  let versionFileContents = contents;
+
+  if (path.basename(versionFilePath) === '.nvmrc') {
+    versionFileContents = contents
+      .split(/\r?\n/)
+      .map(line => line.replace(/#.*/, '').trim())
+      .filter(Boolean)
+      .join('\n');
+
+    if (!versionFileContents) {
+      return null;
+    }
+  }
+
+  const found = versionFileContents.match(
+    /^(?:node(js)?\s+)?v?(?<version>[^\s]+)$/m
+  );
+  return found?.groups?.version ?? versionFileContents.trim();
 }
 
 export async function printEnvDetailsAndSetOutput() {


### PR DESCRIPTION
## Description

Fixes #1119.

`getNodeVersionFromFile()` already handles a full-line comment followed by a version in many cases, but some valid `.nvmrc` comment forms are still parsed as part of the Node version. In particular, a comment-only `#` line can be selected as the version, and inline comments or trailing whitespace can leave an invalid version string.

This change applies `.nvmrc`-specific preprocessing before the existing version matcher:

- remove `#` comments
- trim and discard blank lines
- return `null` when the file contains only comments or whitespace

The behavior of `.tool-versions`, JSON package files, and Volta configuration is unchanged. Thanks to @sodic for documenting the failing cases in #1119.

The committed `dist/setup` and `dist/cache-save` bundles were rebuilt from the updated source.

## Validation

- `npm run pre-checkin`
- `npm run format-check`
- `npm run lint`
- `npm test` — 11 suites and 235 tests passed
- `git diff --check`
