### PR TITLE
docs: add V7 ESM migration and NODE_AUTH_TOKEN behavior change

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,13 @@ This action provides the following functionality for GitHub Actions users:
 - Registering problem matchers for error output
 - Configuring authentication for GPR or npm
 
-## Breaking changes in V7
+## What's new in V7
 
-- **Migrated to ESM** to enable support for the latest `@actions/*` package versions.
+- Migrated action internals to ESM for compatibility with latest `@actions/*` packages. No changes to action inputs, outputs, or behavior.
+
+### Breaking change
+
+- The dummy `NODE_AUTH_TOKEN` fallback has been removed, as it could unintentionally affect the generated `.npmrc` with a non-functional token. With this change, if `registry-url` is set without `NODE_AUTH_TOKEN`, legacy Yarn Classic (1.x) and older Node/npm versions may fail, and pnpm may warn. npm Trusted Publishing (OIDC) is not affected, since it does not use `NODE_AUTH_TOKEN`.
 
 ## Breaking changes in V6
 
@@ -30,7 +34,7 @@ This action provides the following functionality for GitHub Actions users:
 - Upgraded action from node20 to node24.
   > Make sure your runner is on version v2.327.1 or later to ensure compatibility with this release. [See Release Notes](https://github.com/actions/runner/releases/tag/v2.327.1)
 
-For more details, see the full release notes on the [releases page](https://github.com/actions/setup-node/releases/v5.0.0)
+For more details, see the full release notes on the [releases page](https://github.com/actions/setup-node/releases)
 
 ## Usage
 


### PR DESCRIPTION
**Description:**
Update the README V7 notes to document both the internal ESM migration and the NODE_AUTH_TOKEN fallback removal.

**Related issue:**

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.